### PR TITLE
fix: mir grid handling due to anemoi-inference

### DIFF
--- a/inference/src/anemoi/plugins/ecmwf/inference/mir_templates/mir_templates.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/mir_templates/mir_templates.py
@@ -103,9 +103,9 @@ class MirTemplatesProvider(TemplateProvider):
             grid = "/".join(map(str, grid))
         if isinstance(area, (list, tuple)):
             area = "/".join(map(str, area))
-        
+
         if isinstance(grid, (int, float)):
-            grid = f"{grid}/{grid}" # Convert single value to a grid string, introduced by choice in anemoi-inference.
+            grid = f"{grid}/{grid}"  # Convert single value to a grid string, introduced by choice in anemoi-inference.
 
         base_template = self._base_template_provider.template(variable, lookup)
         if base_template is None:


### PR DESCRIPTION
### Description
Anemoi inference resolves a grid of [0.1,0.1] to 0.1, 

MIR requires "0.1/0.1"

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 