### PR TITLE
fix: [opendata] Use `od` instead of `ea`

### DIFF
--- a/inference/src/anemoi/plugins/ecmwf/inference/opendata/opendata.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/opendata/opendata.py
@@ -106,6 +106,8 @@ def retrieve(
     result = ekd.SimpleFieldList()
     for r in requests:
         r.update(kwargs)
+        if r.get("class") in ("rd", "ea"):
+            r["class"] = "od"
 
         if patch:
             r = patch(r)


### PR DESCRIPTION
### Description
`ea` is not available in opendata, use `od` instead

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 