### PR TITLE
feat(inference.multio): Add sinks argument to plan output

### DIFF
--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/README.md
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/README.md
@@ -36,11 +36,11 @@ output:
           actions:
           - type: encode-mtg2
           - type: sink
-              sinks:
-              - type: file
-                append: true
-                per-server: false
-                path: 'output.grib'
+            sinks:
+            - type: file
+              append: true
+              per-server: false
+              path: 'output.grib'
       type: 'fc'
       class: 'ai'
       expver: '0001'

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/README.md
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/README.md
@@ -38,9 +38,9 @@ output:
           - type: sink
               sinks:
               - type: file
-              append: true
-              per-server: false
-              path: 'output.grib'
+                append: true
+                per-server: false
+                path: 'output.grib'
       type: 'fc'
       class: 'ai'
       expver: '0001'

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
@@ -242,6 +242,8 @@ class MultioOutputPlugin(Output):
             if self._archiver:
                 self._archiver.add(_to_mars(metadata, self._user_defined_metadata))
 
+        self._server.flush()
+
     def close(self) -> None:
         if self._server is None:
             raise RuntimeError("Multio server is not open to close, call `.open()` first.")

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
@@ -242,8 +242,6 @@ class MultioOutputPlugin(Output):
             if self._archiver:
                 self._archiver.add(_to_mars(metadata, self._user_defined_metadata))
 
-        self._server.flush()
-
     def close(self) -> None:
         if self._server is None:
             raise RuntimeError("Multio server is not open to close, call `.open()` first.")

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
@@ -126,7 +126,7 @@ class MultioOutputPlugin(Output):
     def __init__(
         self,
         context: Context,
-        plan: str | dict | multio.plans.Plan,
+        plan: str | dict | multio.plans.Client | multio.plans.Server,
         *,
         output_frequency: int | None = None,
         write_initial_state: bool | None = None,
@@ -181,7 +181,7 @@ class MultioOutputPlugin(Output):
         namer = self.context.checkpoint.default_namer()
 
         LOG.info(f"Copying step 0 diagnostic fields from {self._initial_state_diagnostics_grib} to output:")
-        for field in ds:
+        for field in ds:  # type: ignore
             name = namer(field, field.metadata())
             if name in state["fields"]:
                 raise ValueError(f"Field {name!r} already exists in the initial state.")

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
@@ -254,6 +254,20 @@ class MultioOutputPlugin(Output):
             self._archiver.write(source=self.source, use_grib_paramid=self.context.use_grib_paramid)
 
 
+def add_debug(locations: dict[int, str], plan: multio.plans.Plan) -> None:
+    """Add debug print actions in place to a multio plan at specified locations.
+
+    Parameters
+    ----------
+    locations : dict[int, str]
+        A dictionary mapping action indices to debug prefixes.
+    plan : multio.plans.Plan
+        The multio plan to modify.
+    """
+    for index, prefix in sorted(locations.items(), reverse=True):
+        plan.actions.insert(index, multio.plans.Print(stream="cout", prefix=prefix, only_fields=False))
+
+
 @main_argument("path")
 class MultioOutputGribPlugin(MultioOutputPlugin):
     """Multio output plugin for GRIB files.
@@ -308,12 +322,7 @@ class MultioOutputGribPlugin(MultioOutputPlugin):
             ]
         )
         if debug:
-            plan.plans[0].actions.insert(
-                0, multio.plans.Print(stream="cout", prefix="MULTIO PRE-ENC DEBUG: ", only_fields=False)
-            )
-            plan.plans[0].actions.insert(
-                2, multio.plans.Print(stream="cout", prefix="MULTIO PST-ENC DEBUG: ", only_fields=False)
-            )
+            add_debug({0: "MULTIO PRE-ENC DEBUG: ", 2: "MULTIO PST-ENC DEBUG: "}, plan.plans[0])
 
         super().__init__(context, plan=plan, **kwargs)
 
@@ -358,12 +367,7 @@ class MultioOutputFDBPlugin(MultioOutputPlugin):
             ]
         )
         if debug:
-            plan.plans[0].actions.insert(
-                0, multio.plans.Print(stream="cout", prefix="MULTIO PRE-ENC DEBUG: ", only_fields=False)
-            )
-            plan.plans[0].actions.insert(
-                2, multio.plans.Print(stream="cout", prefix="MULTIO PST-ENC DEBUG: ", only_fields=False)
-            )
+            add_debug({0: "MULTIO PRE-ENC DEBUG: ", 2: "MULTIO PST-ENC DEBUG: "}, plan.plans[0])
 
         super().__init__(context, plan=plan, **kwargs)
 

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
@@ -148,6 +148,11 @@ class MultioOutputPlugin(Output):
         except TypeError as e:
             raise TypeError(f"Invalid metadata: {e}") from e
 
+        dumped_plan = (
+            self._plan.dump_yaml() if isinstance(self._plan, multio.plans.plans.MultioBaseModel) else self._plan
+        )
+        LOG.info("Using Multio plan:\n%s", dumped_plan)
+
     def open(self, state: State) -> None:
         if self._server is None:
             with multio.MultioPlan(self._plan):  # type: ignore


### PR DESCRIPTION
### Description
Allow for sinks to be set seperately to actions within the plan

## i.e
```
output:
  multio:
    type: 'fc'
    class: 'ai'
    expver: '0001'
    model: 'aifs-single'
    stream: 'oper'
    plan:
        plans:
        - name: output-to-file
          actions:
          - type: encode-mtg2
            geo-from-atlas: true
          - type: scale
            preset-mappings: local-to-wmo
    sinks:
      - type: file
        append: false
        per-server: false
        path: 'output.grib'
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 