### PR TITLE
feat(inference, polytope): Allow for grid / area to be set in config

### DIFF
--- a/inference/src/anemoi/plugins/ecmwf/inference/polytope/polytope.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/polytope/polytope.py
@@ -82,8 +82,12 @@ def retrieve(
 
         LOG.debug("%s", _(r))
 
-        result += ekd.from_source("polytope", collection, r, stream=False)
-
+        # Temporarily disable debug logging in this context
+        logging.disable(logging.DEBUG)  # Due to polytope spamming logs
+        try:
+            result += ekd.from_source("polytope", collection, r, stream=False)
+        finally:
+            logging.disable(logging.NOTSET)
     return result
 
 
@@ -99,7 +103,7 @@ class PolytopeInputPlugin(MarsInput):
         collection: str | None = None,
         **kwargs: Any,
     ):
-        """Initialize the Polytope input plugin.
+        """Initialise the Polytope input plugin.
 
         Parameters
         ----------
@@ -140,12 +144,12 @@ class PolytopeInputPlugin(MarsInput):
 
         kwargs = self.kwargs.copy()
         kwargs.setdefault("expver", "0001")
+        kwargs.setdefault("grid", self.checkpoint.grid)
+        kwargs.setdefault("area", self.checkpoint.area)
 
         return retrieve(
             self.collection,
             requests,
-            self.checkpoint.grid,
-            self.checkpoint.area,
-            self.patch,
+            patch=self.patch,
             **kwargs,
         )


### PR DESCRIPTION
### Description
Allow for grid / area to be set in config

```
input:
  cutout:
    lam_0:
      polytope:
        grid: 0.025/0.025
        area: AREA/AREA/AREA/AREA
    global: 
      polytope:
        grid: n320
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 