### PR TITLE
feat!: Update all plugins to work with multi-dataset in inference

### DIFF
--- a/inference/pyproject.toml
+++ b/inference/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 
 dynamic = [ "version" ]
 dependencies = [
-  "anemoi-inference>=0.8.1",
+  "anemoi-inference>=0.11",
 ]
 
 optional-dependencies.all = [ "anemoi-plugins-ecmwf-inference[mir,multio,opendata,polytope]" ]

--- a/inference/src/anemoi/plugins/ecmwf/inference/dynamics/array_overlay.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/dynamics/array_overlay.py
@@ -7,10 +7,10 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-
 import functools
 import logging
 from os import PathLike
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 
@@ -20,6 +20,10 @@ import numpy as np
 from anemoi.inference.processor import Processor
 
 from ._operate_on_fields import apply_function_to_fields
+
+if TYPE_CHECKING:
+    from anemoi.inference.context import Context
+    from anemoi.inference.metadata import Metadata
 
 LOG = logging.getLogger(__name__)
 
@@ -67,14 +71,16 @@ class ArrayOverlayPlugin(Processor):
 
     def __init__(
         self,
-        context,
+        context: "Context",
+        metadata: "Metadata",
+        *,
         overlay: PathLike,
         fields: list[dict[str, Any]],
         rescale: float = 1,
         method: VALID_METHODS = "add",
         invert: bool = False,
     ):
-        super().__init__(context)
+        super().__init__(context, metadata)
 
         self._overlay = overlay
         self._fields = fields
@@ -143,7 +149,7 @@ class ArrayOverlayPlugin(Processor):
         LOG.debug("ImageOverlay: Applying image overlay to %s.", field)
         data = field.to_numpy()
 
-        image_array = self.prepare_overlay(self.checkpoint.grid) / 255.0
+        image_array = self.prepare_overlay(self.metadata.grid) / 255.0
         rescaled_array = ((1 - image_array) if self._invert else image_array) * self._rescale
 
         if self._method == "add":

--- a/inference/src/anemoi/plugins/ecmwf/inference/dynamics/modify_value.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/dynamics/modify_value.py
@@ -7,6 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 
@@ -15,6 +16,10 @@ import numpy as np
 from anemoi.inference.processor import Processor
 
 from ._operate_on_fields import apply_function_to_fields
+
+if TYPE_CHECKING:
+    from anemoi.inference.context import Context
+    from anemoi.inference.metadata import Metadata
 
 VALID_METHODS = Literal["add", "subtract", "multiply", "divide", "replace"]
 METHOD_FUNCTIONS = {
@@ -41,8 +46,17 @@ class ModifyValuePlugin(Processor):
     ```
     """
 
-    def __init__(self, context, fields: list[dict[str, Any]], value: float | str, method: VALID_METHODS = "add"):
-        super().__init__(context)
+    def __init__(
+        self,
+        context: "Context",
+        metadata: "Metadata",
+        *,
+        fields: list[dict[str, Any]],
+        value: float | str,
+        method: VALID_METHODS = "add",
+    ):
+        super().__init__(context, metadata)
+
         self.method = method
         if isinstance(value, str):
             value = np.load(value)

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
@@ -18,8 +18,10 @@ import multio
 import numpy as np
 from anemoi.inference.context import Context
 from anemoi.inference.decorators import main_argument
+from anemoi.inference.metadata import Metadata
 from anemoi.inference.output import Output
 from anemoi.inference.post_processors.accumulate import Accumulate
+from anemoi.inference.types import ProcessorConfig
 from anemoi.inference.types import State
 from anemoi.utils.grib import shortname_to_paramid
 from pydantic import BaseModel
@@ -134,16 +136,22 @@ class MultioOutputPlugin(Output):
     def __init__(
         self,
         context: Context,
+        metadata: Metadata,
         plan: str | dict | multio.plans.Client | multio.plans.Server,
         *,
+        variables: list[str] | None = None,
+        post_processors: list[ProcessorConfig] | None = None,
         output_frequency: int | None = None,
         write_initial_state: bool | None = None,
         archive_requests: Config | None = None,
         initial_state_diagnostics_grib: str | None = None,
-        **metadata: Any,
+        **user_metadata: Any,
     ) -> None:
         super().__init__(
             context,
+            metadata=metadata,
+            variables=variables,
+            post_processors=post_processors,
             output_frequency=output_frequency,
             write_initial_state=write_initial_state,
         )
@@ -152,9 +160,9 @@ class MultioOutputPlugin(Output):
         self._initial_state_diagnostics_grib = initial_state_diagnostics_grib
 
         try:
-            self._user_defined_metadata = UserDefinedMetadata(**metadata)
+            self._user_defined_metadata = UserDefinedMetadata(**user_metadata)
         except TypeError as e:
-            raise TypeError(f"Invalid metadata: {e}") from e
+            raise TypeError(f"Invalid user_metadata: {e}") from e
 
         dumped_plan = (
             self._plan.dump_yaml() if isinstance(self._plan, multio.plans.plans.MultioBaseModel) else self._plan
@@ -163,7 +171,7 @@ class MultioOutputPlugin(Output):
 
     @cached_property
     def _is_accumulated_from_start(self) -> bool:
-        return any(isinstance(x, Accumulate) for x in self.context.create_post_processors())
+        return any(isinstance(x, Accumulate) for k in self.context.post_processors for x in self.context.post_processors[k])  # type: ignore[reportAttributeAccessIssue]
 
     def open(self, state: State) -> None:
         if self._server is None:
@@ -200,7 +208,7 @@ class MultioOutputPlugin(Output):
         import earthkit.data as ekd
 
         ds = ekd.from_source("file", self._initial_state_diagnostics_grib)
-        namer = self.context.checkpoint.default_namer()
+        namer = self.metadata.default_namer()
 
         LOG.info(f"Copying step 0 diagnostic fields from {self._initial_state_diagnostics_grib} to output:")
         for field in ds:  # type: ignore
@@ -220,12 +228,12 @@ class MultioOutputPlugin(Output):
 
         shared_metadata = {
             "step": int(step.total_seconds() // 3600),
-            "grid": str(self.context.checkpoint.grid).upper(),
+            "grid": str(self.metadata.grid).upper(),
             "date": int(reference_date.strftime("%Y%m%d")),  # type: ignore
             "time": int(reference_date.strftime("%H%M%S")),  # type: ignore
         }
 
-        timespan = self.context.checkpoint.timestep.total_seconds() // 3600
+        timespan = self.metadata.timestep.total_seconds() // 3600
         if self._is_accumulated_from_start:
             timespan = shared_metadata["step"]
 
@@ -320,6 +328,8 @@ class MultioOutputGribPlugin(MultioOutputPlugin):
     def __init__(
         self,
         context: Context,
+        metadata: Metadata,
+        *,
         path: str,
         append: bool = False,
         per_server: bool = False,
@@ -332,6 +342,8 @@ class MultioOutputGribPlugin(MultioOutputPlugin):
         ----------
         context : Context
             Model Runner
+        metadata : Metadata
+            Metadata for the output plugin
         path : str
             Path to write to
         append : bool
@@ -348,7 +360,7 @@ class MultioOutputGribPlugin(MultioOutputPlugin):
                 multio.plans.Plan(
                     name="output-to-file",
                     actions=[
-                        multio.plans.EncodeMTG(geo_from_atlas=True),
+                        multio.plans.EncodeMTG(),
                         multio.plans.Sink(
                             sinks=[
                                 multio.plans.sinks.File(
@@ -365,7 +377,7 @@ class MultioOutputGribPlugin(MultioOutputPlugin):
         if debug:
             add_debug({0: "MULTIO PRE-ENC DEBUG: ", 2: "MULTIO PST-ENC DEBUG: "}, plan.plans[0])
 
-        super().__init__(context, plan=plan, **kwargs)
+        super().__init__(context, metadata=metadata, plan=plan, **kwargs)
 
 
 @main_argument("fdb_config")
@@ -376,13 +388,17 @@ class MultioOutputFDBPlugin(MultioOutputPlugin):
     It is a subclass of the MultioOutputPlugin class.
     """
 
-    def __init__(self, context: Context, fdb_config: str, debug: bool = False, **kwargs: Any) -> None:
+    def __init__(
+        self, context: Context, metadata: Metadata, fdb_config: str, *, debug: bool = False, **kwargs: Any
+    ) -> None:
         """Multio FDB Output Plugin.
 
         Parameters
         ----------
         context : Context
             Model Runner
+        metadata : Metadata
+            Metadata for the output plugin
         fdb_config : str
             FDB Configuration file
         debug : bool, optional
@@ -395,7 +411,7 @@ class MultioOutputFDBPlugin(MultioOutputPlugin):
                 multio.plans.Plan(
                     name="output-to-fdb",
                     actions=[
-                        multio.plans.EncodeMTG(geo_from_atlas=True),
+                        multio.plans.EncodeMTG(),
                         multio.plans.Sink(
                             sinks=[
                                 multio.plans.sinks.FDB(
@@ -410,7 +426,7 @@ class MultioOutputFDBPlugin(MultioOutputPlugin):
         if debug:
             add_debug({0: "MULTIO PRE-ENC DEBUG: ", 2: "MULTIO PST-ENC DEBUG: "}, plan.plans[0])
 
-        super().__init__(context, plan=plan, **kwargs)
+        super().__init__(context, metadata=metadata, plan=plan, **kwargs)
 
 
 @main_argument("plan")
@@ -418,7 +434,13 @@ class MultioOutputPlanPlugin(MultioOutputPlugin):
     """Multio output plugin to write with a plan."""
 
     def __init__(
-        self, context: Context, plan: str | dict, *, sinks: list[multio.plans.sinks.SINKS] | None = None, **kwargs: Any
+        self,
+        context: Context,
+        metadata: Metadata,
+        plan: str | dict,
+        *,
+        sinks: list[multio.plans.sinks.SINKS] | None = None,
+        **kwargs: Any,
     ) -> None:
         """Multio FDB Output Plugin.
 
@@ -426,6 +448,8 @@ class MultioOutputPlanPlugin(MultioOutputPlugin):
         ----------
         context : Context
             Model Runner
+        metadata : Metadata
+            Metadata for the output plugin
         plan : str | dict
             Multio Plan
         sinks : list[multio.plans.sinks.SINKS] | None
@@ -444,7 +468,7 @@ class MultioOutputPlanPlugin(MultioOutputPlugin):
                 p.actions.append(multio.plans.Sink(sinks=sinks))
             plan = realised_plan  # type: ignore
 
-        super().__init__(context, plan=plan, **kwargs)
+        super().__init__(context, metadata=metadata, plan=plan, **kwargs)
 
 
 class MultioDisambiguousOutputPlugin(MultioOutputPlugin):

--- a/inference/src/anemoi/plugins/ecmwf/inference/opendata/geopotential_height.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/opendata/geopotential_height.py
@@ -9,6 +9,7 @@
 
 
 import logging
+from typing import TYPE_CHECKING
 from typing import Any
 
 from anemoi.inference.processor import Processor
@@ -16,6 +17,10 @@ from anemoi.inference.types import State
 from anemoi.transform.filters.fields.orog_to_z import Orography
 
 LOG = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from anemoi.inference.context import Context
+    from anemoi.inference.metadata import Metadata
 
 
 class InferenceOrography(Orography):
@@ -39,17 +44,19 @@ class InferenceOrography(Orography):
 class OrographyProcessor(Processor):
     """A processor that applies the InferenceOrography filter to the given fields."""
 
-    def __init__(self, context: Any, **kwargs: Any) -> None:
+    def __init__(self, context: "Context", metadata: "Metadata", **kwargs: Any) -> None:
         """Initialize the OrographyProcessor.
 
         Parameters
         ----------
-        context : object
+        context : Context
             The context in which the filter is being used.
+        metadata : Metadata
+            The metadata associated with the processor.
         **kwargs : dict
             Additional keyword arguments to pass to the filter.
         """
-        super().__init__(context)
+        super().__init__(context, metadata)
         self.filter = InferenceOrography(**kwargs)
 
     def process(self, state: State) -> State:

--- a/inference/src/anemoi/plugins/ecmwf/inference/opendata/opendata.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/opendata/opendata.py
@@ -18,6 +18,7 @@ import earthkit.data as ekd
 import yaml
 from anemoi.inference.context import Context
 from anemoi.inference.inputs.mars import MarsInput
+from anemoi.inference.metadata import Metadata
 from anemoi.inference.types import DataRequest
 from anemoi.inference.types import Date
 from anemoi.utils.grib import shortname_to_paramid
@@ -231,7 +232,7 @@ def _rename_params(fieldlist: ekd.FieldList) -> ekd.FieldList:
 def retrieve(
     requests: list[dict[str, Any]],
     grid: str | list[float] | None,
-    area: list[float] | None,
+    area: list[float] | str | None,
     patch: Any | None = None,
     **kwargs: Any,
 ) -> ekd.FieldList:
@@ -243,7 +244,7 @@ def retrieve(
         The list of requests to be retrieved.
     grid : Optional[Union[str, list[float]]]
         The grid for the retrieval.
-    area : Optional[list[float]]
+    area : Optional[Union[list[float], str]]
         The area for the retrieval.
     patch : Optional[Any], optional
         Optional patch for the request, by default None.
@@ -291,6 +292,7 @@ class OpenDataInputPlugin(MarsInput):
     def __init__(
         self,
         context: Context,
+        metadata: Metadata,
         **kwargs: Any,
     ) -> None:
         """Initialise the OpenDataInput.
@@ -299,13 +301,15 @@ class OpenDataInputPlugin(MarsInput):
         ----------
         context : Any
             The context in which the input is used.
+        metadata : Metadata
+            The metadata associated with the input.
         """
         rules_for_namer = [
             ({"levtype": "sol"}, "{param}"),
         ]
         kwargs.pop("namer", None)  # Ensure namer is not passed to MarsInput
-        super().__init__(context, namer={"rules": rules_for_namer}, **kwargs)
-        self.pre_processors.append(OrographyProcessor(context=context, orog="gh"))
+        super().__init__(context, metadata=metadata, namer={"rules": rules_for_namer}, **kwargs)
+        self.pre_processors.append(OrographyProcessor(context=context, metadata=metadata, orog="gh"))
 
         if self.context.use_grib_paramid:
             LOG.warning("`use_grib_paramid=True` is not supported for ECMWF Open Data and will be ignored.")
@@ -326,7 +330,7 @@ class OpenDataInputPlugin(MarsInput):
             The retrieved data.
         """
 
-        requests = self.checkpoint.mars_requests(
+        requests = self.metadata.mars_requests(
             variables=variables,
             dates=dates,
             use_grib_paramid=False,
@@ -337,11 +341,11 @@ class OpenDataInputPlugin(MarsInput):
             raise ValueError(f"No requests for {variables} ({dates})")
 
         kwargs = self.kwargs.copy()
+        kwargs.setdefault("grid", self.metadata.grid)
+        kwargs.setdefault("area", self.metadata.area)
 
         return retrieve(
             requests,
-            self.checkpoint.grid,
-            self.checkpoint.area,
             patch=self.patch_data_request,
             **kwargs,
         )

--- a/inference/src/anemoi/plugins/ecmwf/inference/polytope/polytope.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/polytope/polytope.py
@@ -149,7 +149,7 @@ class PolytopeInputPlugin(MarsInput):
 
         kwargs = self.kwargs.copy()
         kwargs.setdefault("expver", "0001")
-        
+
         kwargs.setdefault("grid", self.metadata.grid)
         kwargs.setdefault("area", self.metadata.area)
         kwargs.setdefault("stream", "oper")

--- a/inference/src/anemoi/plugins/ecmwf/inference/polytope/polytope.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/polytope/polytope.py
@@ -14,6 +14,7 @@ from anemoi.inference.context import Context
 from anemoi.inference.decorators import main_argument
 from anemoi.inference.inputs.mars import MarsInput
 from anemoi.inference.inputs.mars import postproc
+from anemoi.inference.metadata import Metadata
 from anemoi.inference.types import DataRequest
 from anemoi.inference.types import Date
 
@@ -24,7 +25,7 @@ def retrieve(
     collection: str,
     requests: list[dict[str, Any]],
     grid: str | list[float] | None,
-    area: list[float] | None,
+    area: list[float] | str | None,
     patch: Any | None = None,
     **kwargs: Any,
 ) -> Any:
@@ -38,7 +39,7 @@ def retrieve(
         The list of requests to be retrieved.
     grid : Optional[Union[str, List[float]]]
         The grid for the retrieval.
-    area : Optional[List[float]]
+    area : Optional[Union[List[float], str]]
         The area for the retrieval.
     patch : Optional[Any], optional
         Optional patch for the request, by default None.
@@ -100,7 +101,9 @@ class PolytopeInputPlugin(MarsInput):
     def __init__(
         self,
         context: Context,
-        collection: str | None = None,
+        metadata: Metadata,
+        *,
+        collection: str = "ecmwf-mars",
         **kwargs: Any,
     ):
         """Initialise the Polytope input plugin.
@@ -109,13 +112,15 @@ class PolytopeInputPlugin(MarsInput):
         ----------
         context : Context
             The context for the input plugin.
+        metadata : Metadata
+            The metadata associated with the input plugin.
         collection : Optional[str], optional
             The collection to use for retrieval, by default 'ecmwf-mars'.
         **kwargs : Any
             Additional keyword arguments.
         """
-        super().__init__(context, **kwargs)
-        self.collection = collection or "ecmwf-mars"
+        super().__init__(context, metadata, **kwargs)
+        self.collection = collection
 
     def retrieve(self, variables: list[str], dates: list[Date]) -> Any:
         """Retrieve data for the given variables and dates.
@@ -132,7 +137,7 @@ class PolytopeInputPlugin(MarsInput):
         Any
             The retrieved data.
         """
-        requests = self.checkpoint.mars_requests(
+        requests = self.metadata.mars_requests(
             variables=variables,
             dates=dates,
             use_grib_paramid=self.context.use_grib_paramid,
@@ -144,8 +149,8 @@ class PolytopeInputPlugin(MarsInput):
 
         kwargs = self.kwargs.copy()
         kwargs.setdefault("expver", "0001")
-        kwargs.setdefault("grid", self.checkpoint.grid)
-        kwargs.setdefault("area", self.checkpoint.area)
+        kwargs.setdefault("grid", self.metadata.grid)
+        kwargs.setdefault("area", self.metadata.area)
 
         return retrieve(
             self.collection,

--- a/inference/src/anemoi/plugins/ecmwf/inference/regrid/regrid.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/regrid/regrid.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import earthkit.data as ekd
 import tqdm
 from anemoi.inference.context import Context
+from anemoi.inference.metadata import Metadata
 from anemoi.inference.processor import Processor
 from anemoi.inference.types import State
 
@@ -23,7 +24,7 @@ if TYPE_CHECKING:
 LOG = logging.getLogger(__name__)
 
 
-def _mir_regrid(field: "GribField", grid, area) -> "GribField":
+def _mir_regrid(field: "GribField", grid: str | list[float], area: str | list[float] | None) -> "GribField":
     import io
 
     import mir
@@ -45,7 +46,7 @@ def _mir_regrid(field: "GribField", grid, area) -> "GribField":
     return ekd.from_source("memory", buffer.getvalue())[0]  # type: ignore
 
 
-def regrid(fields: ekd.FieldList, grid, area) -> ekd.FieldList:
+def regrid(fields: ekd.FieldList, grid: str | list[float], area: str | list[float] | None) -> ekd.FieldList:
     """Regrid a list of fields to a specified grid and area.
 
     TO BE REPLACED WITH EARTHKIT-REGRID
@@ -66,19 +67,23 @@ class RegridPreprocessor(Processor):
     i.e. mars, cds, opendata, grib files, etc.
     """
 
-    def __init__(self, context: Context, grid: str | list[float], area: str | list[float] | None = None) -> None:
+    def __init__(
+        self, context: Context, metadata: Metadata, *, grid: str | list[float], area: str | list[float] | None = None
+    ) -> None:
         """Initialize the Regridding processor.
 
         Parameters
         ----------
         context : Context
             The context in which the processor operates.
+        metadata : Metadata
+            The metadata associated with the dataset this processor is handling.
         grid : str | list[float]
             The target grid for regridding.
         area : str | list[float] | None, optional
             The target area for regridding, by default None
         """
-        super().__init__(context)
+        super().__init__(context, metadata=metadata)
         self._grid = grid
         self._area = area
 

--- a/inference/tests/conftest.py
+++ b/inference/tests/conftest.py
@@ -7,7 +7,6 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-
 from datetime import datetime
 from datetime import timedelta
 
@@ -15,11 +14,19 @@ import numpy as np
 import pytest
 from anemoi.inference.types import State
 
+
+@pytest.fixture
+def mock_metadata(mocker):
+    from anemoi.inference.metadata import Metadata
+
+    return mocker.MagicMock(spec=Metadata)
+
+
 STATE_NPOINTS = 50
 
 
 @pytest.fixture
-def state() -> State:
+def mock_state() -> State:
     """Fixture to create a mock state for testing."""
 
     return {

--- a/inference/tests/dynamics/test_modify_value.py
+++ b/inference/tests/dynamics/test_modify_value.py
@@ -12,6 +12,7 @@ import earthkit.data as ekd
 import numpy as np
 import pytest
 from anemoi.inference.context import Context
+from anemoi.inference.metadata import Metadata
 from anemoi.plugins.ecmwf.inference.dynamics.modify_value import ModifyValuePlugin
 from pytest_mock import MockerFixture
 
@@ -35,8 +36,9 @@ def mock_fields() -> ekd.FieldList:
 def test_modify_value(mocker: MockerFixture, mock_fields: ekd.FieldList, value):
     # mock the context to return the mask when load_supporting_array is called
     context = cast(Context, mocker.MagicMock())
+    metadata = cast(Metadata, mocker.MagicMock())
     field_specifier = [{"shortName": "2t"}]
-    processor = ModifyValuePlugin(context=context, fields=field_specifier, value=value, method="add")
+    processor = ModifyValuePlugin(context=context, metadata=metadata, fields=field_specifier, value=value, method="add")
 
     # check that assignment works as expected
     new_state = processor.process(fields=mock_fields)
@@ -61,8 +63,11 @@ def test_modify_value_with_numpy_file(mocker: MockerFixture, mock_fields: ekd.Fi
 
     # mock the context to return the mask when load_supporting_array is called
     context = cast(Context, mocker.MagicMock())
+    metadata = cast(Metadata, mocker.MagicMock())
     field_specifier = [{"shortName": "2t"}]
-    processor = ModifyValuePlugin(context=context, fields=field_specifier, value=str(numpy_file), method="add")
+    processor = ModifyValuePlugin(
+        context=context, metadata=metadata, fields=field_specifier, value=str(numpy_file), method="add"
+    )
 
     # check that assignment works as expected
     new_state = processor.process(fields=mock_fields)

--- a/inference/tests/multio/configs/multio.yaml
+++ b/inference/tests/multio/configs/multio.yaml
@@ -1,6 +1,7 @@
 ---
 checkpoint: checkpoints/multio.ckpt
 date: 2020-01-01
+input: dummy
 output:
   multio:
     path: /dev/null

--- a/inference/tests/multio/configs/simple.yaml
+++ b/inference/tests/multio/configs/simple.yaml
@@ -1,3 +1,4 @@
 ---
 checkpoint: checkpoints/simple.ckpt
 date: 2020-01-01
+input: dummy

--- a/inference/tests/multio/test_multio.py
+++ b/inference/tests/multio/test_multio.py
@@ -87,32 +87,6 @@ def test_multio_write_field_called(mock_multio_server, mock_state: State) -> Non
 
 
 @fake_checkpoints
-def test_multio_workflow_called(mock_multio_server) -> None:
-    """Test the inference process using a fake checkpoint.
-
-    This function loads a configuration, creates a runner, and runs the inference
-    process to ensure that the system works as expected with the provided configuration.
-    """
-    # Load configuration
-    config = MockRunConfiguration.load(
-        str((Path(__file__).parent / "configs/multio.yaml").absolute()),
-        overrides=dict(runner="no-model", device="cpu", input="dummy"),
-    )
-
-    # Create runner and execute
-    runner = create_runner(config)  # type: ignore
-
-    # Check calls to the _server property
-    assert hasattr(runner.create_output("data", runner.tensor_handlers["data"].metadata), "_server")
-
-    runner.execute()
-
-    mock_multio_server.write_field.assert_called()
-    mock_multio_server.flush.assert_called()
-    mock_multio_server.close_connections.assert_called()
-
-
-@fake_checkpoints
 def test_multio_archiver(mock_multio_server, mock_state) -> None:
     """Test archiver"""
 

--- a/inference/tests/multio/test_multio.py
+++ b/inference/tests/multio/test_multio.py
@@ -37,7 +37,7 @@ def mock_multio_server():
 
 
 @fake_checkpoints
-def test_multio_write_field_called(mock_multio_server, state: State) -> None:
+def test_multio_write_field_called(mock_multio_server, mock_state: State) -> None:
     """Test the write_field method of the MultioOutputPlugin using a fake checkpoint.
 
     This function creates a MultioOutputPlugin instance, opens it with a mock state,
@@ -46,17 +46,17 @@ def test_multio_write_field_called(mock_multio_server, state: State) -> None:
     # Load configuration
     config = MockRunConfiguration.load(
         str((Path(__file__).parent / "configs/multio.yaml").absolute()),
-        overrides=dict(runner="testing", device="cpu", input="dummy"),
+        overrides=dict(runner="no-model", device="cpu", input="dummy"),
     )
 
     runner = create_runner(config)  # type: ignore
-    output = runner.create_output()
+    output = runner.create_output("data", runner.tensor_handlers["data"].metadata)
 
-    output.open(state)
-    output.reference_date = state["date"]
+    output.open(mock_state)
+    output.reference_date = mock_state["date"]
     assert hasattr(output, "_server") and output._server is mock_multio_server
 
-    output.write_step(state)
+    output.write_step(mock_state)
     output.close()
 
     # Check that write_field was called with metadata and field data
@@ -96,14 +96,14 @@ def test_multio_workflow_called(mock_multio_server) -> None:
     # Load configuration
     config = MockRunConfiguration.load(
         str((Path(__file__).parent / "configs/multio.yaml").absolute()),
-        overrides=dict(runner="testing", device="cpu", input="dummy"),
+        overrides=dict(runner="no-model", device="cpu", input="dummy"),
     )
 
     # Create runner and execute
     runner = create_runner(config)  # type: ignore
 
     # Check calls to the _server property
-    assert hasattr(runner.create_output(), "_server")
+    assert hasattr(runner.create_output("data", runner.tensor_handlers["data"].metadata), "_server")
 
     runner.execute()
 
@@ -113,7 +113,7 @@ def test_multio_workflow_called(mock_multio_server) -> None:
 
 
 @fake_checkpoints
-def test_multio_archiver(mock_multio_server, state) -> None:
+def test_multio_archiver(mock_multio_server, mock_state) -> None:
     """Test archiver"""
 
     output_override = {
@@ -134,18 +134,18 @@ def test_multio_archiver(mock_multio_server, state) -> None:
     # Load configuration
     config = MockRunConfiguration.load(
         str((Path(__file__).parent / "configs/multio.yaml").absolute()),
-        overrides=dict(runner="testing", device="cpu", input="dummy", output=output_override),
+        overrides=dict(runner="no-model", device="cpu", input="dummy", output=output_override),
     )
 
     # Create runner and execute
     runner = create_runner(config)  # type: ignore
-    output = runner.create_output()
+    output = runner.create_output("data", runner.tensor_handlers["data"].metadata)
 
-    output.open(state)
-    output.reference_date = state["date"]
+    output.open(mock_state)
+    output.reference_date = mock_state["date"]
     assert hasattr(output, "_server") and output._server is mock_multio_server
 
-    output.write_step(state)
+    output.write_step(mock_state)
 
     assert output._archiver is not None
 

--- a/inference/tests/multio/test_plugin.py
+++ b/inference/tests/multio/test_plugin.py
@@ -37,13 +37,13 @@ FAKE_METADATA_KEYS = {
     ],
 )
 @fake_checkpoints
-def test_plugin(plugin, kwargs):
+def test_plugin(plugin, kwargs, mock_metadata):
     config = MockRunConfiguration.load(
         str((Path(__file__).parent / "configs/simple.yaml").absolute()),
         overrides=dict(output={plugin: {**kwargs, **FAKE_METADATA_KEYS}}),
     )
     runner = create_runner(config)
-    output = create_output(runner, config.output)
+    output = create_output(runner, config.output, mock_metadata, variables=[])
     assert output is not None
 
 

--- a/inference/tests/opendata/test_plugin.py
+++ b/inference/tests/opendata/test_plugin.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 
+from collections import defaultdict
 from pathlib import Path
 
 from anemoi.inference.inputs import create_input
@@ -17,15 +18,12 @@ from anemoi.inference.testing.mock_checkpoint import MockRunConfiguration
 
 
 @fake_checkpoints
-def test_plugin():
+def test_plugin(mock_metadata) -> None:
     config = MockRunConfiguration.load(
         (Path(__file__).parent / "configs/simple.yaml").absolute(),
         overrides=dict(input="opendata"),
     )
     runner = create_runner(config)
-    input = create_input(runner, config.input, variables=None)
+    runner.pre_processors = defaultdict(list)
+    input = create_input(runner, config.input, mock_metadata, variables=[])
     assert input is not None
-
-
-if __name__ == "__main__":
-    test_plugin()

--- a/inference/tests/polytope/test_plugin.py
+++ b/inference/tests/polytope/test_plugin.py
@@ -17,15 +17,11 @@ from anemoi.inference.testing.mock_checkpoint import MockRunConfiguration
 
 
 @fake_checkpoints
-def test_plugin():
+def test_plugin(mock_metadata) -> None:
     config = MockRunConfiguration.load(
         (Path(__file__).parent / "configs/simple.yaml").absolute(),
         overrides=dict(input="polytope"),
     )
     runner = create_runner(config)
-    input = create_input(runner, config.input, variables=None)
+    input = create_input(runner, config.input, mock_metadata, variables=[])
     assert input is not None
-
-
-if __name__ == "__main__":
-    test_plugin()


### PR DESCRIPTION
### Description
This pull request refactors several plugin classes to require and utilize a `Metadata` object alongside the existing `Context` object. The changes standardize the initialization and usage of metadata across plugins, improve type safety with `TYPE_CHECKING` imports, and clarify parameter types and documentation. Some internal references to checkpoint data have also been updated to use metadata instead.

**Refactor to require and use `Metadata` in plugin initialization:**

- Updated constructors for multiple plugin classes (`ArrayOverlayPlugin`, `ModifyValuePlugin`, `OrographyProcessor`, `OpenDataInputPlugin`, and all `MultioOutputPlugin` variants) to accept and pass a `metadata: Metadata` argument, and to use `metadata` instead of `checkpoint` for grid, timestep, and related information. [[1]](diffhunk://#diff-85003f03625c9eea13a09836ff0e34277bb07b9b0587d9429dcb7a637914d741L70-R83) [[2]](diffhunk://#diff-85003f03625c9eea13a09836ff0e34277bb07b9b0587d9429dcb7a637914d741L146-R152) [[3]](diffhunk://#diff-c70e4c80115574cfc20348b5ca93f94aed1ab41b7670fc302b993f2f88019113L44-R59) [[4]](diffhunk://#diff-9d12ce00c517d82fa28298cc3ad4e289668df9a6bf8bf6827dd8df07a3f762baL42-R59) [[5]](diffhunk://#diff-9d12ce00c517d82fa28298cc3ad4e289668df9a6bf8bf6827dd8df07a3f762baR21-R24) [[6]](diffhunk://#diff-efa02b5a43f9d14699ccef48a82910d4072906807e118d36e4f51d4fa1a658ecR295) [[7]](diffhunk://#diff-efa02b5a43f9d14699ccef48a82910d4072906807e118d36e4f51d4fa1a658ecR304-R312) [[8]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cR139-R154) [[9]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cR331-R332) [[10]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cR345-R346) [[11]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cL368-R380) [[12]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cL379-R401) [[13]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cL398-R414) [[14]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cL413-R452) [[15]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cL447-R471)

**Type safety and code clarity improvements:**

- Added `TYPE_CHECKING` blocks and type annotations for `Context` and `Metadata` imports in relevant files to improve static type checking and avoid circular imports. [[1]](diffhunk://#diff-85003f03625c9eea13a09836ff0e34277bb07b9b0587d9429dcb7a637914d741L10-R13) [[2]](diffhunk://#diff-85003f03625c9eea13a09836ff0e34277bb07b9b0587d9429dcb7a637914d741R24-R27) [[3]](diffhunk://#diff-c70e4c80115574cfc20348b5ca93f94aed1ab41b7670fc302b993f2f88019113R10) [[4]](diffhunk://#diff-c70e4c80115574cfc20348b5ca93f94aed1ab41b7670fc302b993f2f88019113R20-R23) [[5]](diffhunk://#diff-9d12ce00c517d82fa28298cc3ad4e289668df9a6bf8bf6827dd8df07a3f762baR12) [[6]](diffhunk://#diff-9d12ce00c517d82fa28298cc3ad4e289668df9a6bf8bf6827dd8df07a3f762baR21-R24)
- Updated parameter types and docstrings for improved clarity, including allowing `area` to be either a `list[float]` or `str` in `retrieve` functions. [[1]](diffhunk://#diff-efa02b5a43f9d14699ccef48a82910d4072906807e118d36e4f51d4fa1a658ecL234-R235) [[2]](diffhunk://#diff-efa02b5a43f9d14699ccef48a82910d4072906807e118d36e4f51d4fa1a658ecL246-R247)

**Internal logic and naming adjustments:**

- Replaced references to `self.context.checkpoint` with `self.metadata` for grid, timestep, and namer information in plugin logic, ensuring consistent use of metadata. [[1]](diffhunk://#diff-85003f03625c9eea13a09836ff0e34277bb07b9b0587d9429dcb7a637914d741L146-R152) [[2]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cL203-R211) [[3]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cL223-R236) [[4]](diffhunk://#diff-efa02b5a43f9d14699ccef48a82910d4072906807e118d36e4f51d4fa1a658ecL329-R333)
- Improved naming of keyword arguments in `MultioOutputPlugin` to distinguish between user metadata and plugin metadata.

**Multio output plugin enhancements:**

- Updated initialization of `MultioOutputPlugin` and its subclasses to accept additional configuration options (`variables`, `post_processors`), and to use the new metadata handling. [[1]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cR139-R154) [[2]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cL155-R165)
- Changed the internal check for accumulated post-processors to iterate over the new structure of post-processors.

**Other minor improvements:**

- Removed unused or unnecessary arguments (e.g., `geo_from_atlas=True`) in Multio output plan construction. [[1]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cL351-R363) [[2]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cL398-R414)

These changes collectively improve the maintainability, extensibility, and type safety of the codebase by standardizing metadata handling and clarifying plugin interfaces.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
