### PR TITLE
feat(inference/multio): implement hindcast date logic in MultioOutputPlugin

### DIFF
--- a/inference/pyproject.toml
+++ b/inference/pyproject.toml
@@ -74,6 +74,11 @@ entry-points."anemoi.inference.pre_processors"."array_overlay" = "anemoi.plugins
 entry-points."anemoi.inference.pre_processors"."modify_value" = "anemoi.plugins.ecmwf.inference.dynamics:ModifyValuePlugin"
 entry-points."anemoi.inference.pre_processors"."regrid" = "anemoi.plugins.ecmwf.inference.regrid:RegridPreprocessor"
 
+[dependency-groups]
+dev = [
+  "anemoi-plugins-ecmwf-inference[tests]",
+]
+
 [tool.setuptools.package-data]
 "anemoi.plugins.ecmwf.inference.mir_templates" = [ "*.yaml" ]
 "anemoi.plugins.ecmwf.inference.opendata" = [ "*.yaml" ]
@@ -87,6 +92,9 @@ git_describe_command = "git describe --dirty --tags --long --match 'inference-[0
 tag_regex = "^inference-(?P<version>[vV]?[0-9]+[^-]*)"
 version_file = "src/anemoi/plugins/ecmwf/inference/_version.py"
 fallback_version = "0.0.0"
+
+[tool.uv.sources]
+anemoi-plugins-ecmwf-inference = { workspace = true }
 
 [tool.pytest.ini_options]
 testpaths = "tests"

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/README.md
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/README.md
@@ -87,3 +87,17 @@ output:
       # number: 1
       # numberOfForecastsInEnsemble: 50
 ```
+
+### Hindcasts
+
+To use the multio output for hindcasts, simply set `hindcast_reference_year` in the user provided metadata.
+This will then be used as the year in the date key, and `hdate` inserted into the multio write.
+
+```yaml
+output:
+  multio.grib:
+      path: 'output.grib'
+      ...
+      hindcast_reference_year: 2026
+
+```

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/README.md
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/README.md
@@ -90,14 +90,17 @@ output:
 
 ### Hindcasts
 
-To use the multio output for hindcasts, simply set `hindcast_reference_year` in the user provided metadata.
-This will then be used as the year in the date key, and `hdate` inserted into the multio write.
+To use the multio output for hindcasts, set `hindcast_reference_date` in the user provided metadata, to the reference date.
+This will then be used as the date key, and `hdate` inserted into the multio write.
 
 ```yaml
 output:
   multio.grib:
       path: 'output.grib'
       ...
-      hindcast_reference_year: 2026
-
+      hindcast_reference_date: 20260119
 ```
+
+If creating a hindcast for a reference date of a leap day, (29th Feb), set the `hindcast_reference_date` to said leap day,
+As the initial conditions for non leap years must fall on a non leap-day, maintain that for all years of the hindcast.
+This will result in `date` being set correctly as the leap day, and hdate being the true initial condition day.

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+from datetime import datetime
 from datetime import timedelta
 from functools import cached_property
 from typing import Any
@@ -27,6 +28,7 @@ from anemoi.utils.grib import shortname_to_paramid
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_validator
 from pydantic import model_validator
 
 from .archive import ArchiveCollector
@@ -54,6 +56,12 @@ class UserDefinedMetadata(BaseModel):
     """Model name, e.g. aifs-single, ..."""
     number: int | None = None
     """Ensemble number, e.g. 0,1,2"""
+    hindcast_reference_date: int | None = None
+    """Hindcast reference date, e.g. 2020
+        If set, this will be used as the date in the output metadata instead of the state reference date,
+        and the actual initial condition date will be written in the hdate key.
+    """
+
     numberOfForecastsInEnsemble: int | None = Field(None, serialization_alias="misc-numberOfForecastsInEnsemble")
     """Number of ensembles in the forecast, e.g. 50"""
     generatingProcessIdentifier: int | None = Field(None, serialization_alias="misc-generatingProcessIdentifier")
@@ -64,6 +72,12 @@ class UserDefinedMetadata(BaseModel):
         if isinstance(self.number, int) and not isinstance(self.numberOfForecastsInEnsemble, int):
             raise ValueError("numberOfForecastsInEnsemble must be an integer if number is provided")
         return self
+
+    @field_validator("hindcast_reference_date")
+    def validate_hindcast_reference_date(cls, v):
+        if v is not None and (not isinstance(v, int) or len(str(v)) != 4):
+            raise ValueError("hindcast_reference_date must be a 4-digit year, e.g. 2020")
+        return v
 
 
 class MultioMetadata(BaseModel):
@@ -82,7 +96,8 @@ class MultioMetadata(BaseModel):
     """Grid name, e.g. n320, o96"""
     levelist: int | None = None
     """Level, e.g. 0,50,100"""
-
+    hdate: int | None = None
+    """Hindcast initial condition date, e.g. 20200101, only used if hindcast_reference_date is provided in the user metadata"""
     timespan: int | None = None
     """Time span, e.g."""
 
@@ -123,6 +138,20 @@ def _to_mars(metadata: MultioMetadata, user_metadata: UserDefinedMetadata) -> di
         mars_dict["number"] = user_metadata.number
 
     return mars_dict
+
+
+def _handle_hindcast_date(date: datetime, hindcast_reference_date: int | None) -> tuple[datetime, int | None]:
+    """Handle the date and time for the output metadata, taking into account the hindcast reference date if provided."""
+    if hindcast_reference_date is not None:
+        if date.day == 29 and date.month == 2:
+            hdate = int(f"{hindcast_reference_date}0228")
+        else:
+            hdate = int(date.strftime("%Y%m%d"))
+        # If hindcast_reference_date is provided, use it as the year of the date in the output metadata and write the actual reference date in the hdate key
+        reference_date = datetime.fromisoformat(f"{hindcast_reference_date}{date.strftime('%m%dT%H:%M:%S')}")
+        return reference_date, hdate
+    else:
+        return date, None
 
 
 class MultioOutputPlugin(Output):
@@ -180,6 +209,8 @@ class MultioOutputPlugin(Output):
 
         self._server.open_connections()
         user_metadata = self._user_defined_metadata.model_dump(exclude_none=True, by_alias=True)
+        user_metadata.pop("hindcast_reference_date")
+
         if user_metadata.get("stream") == originkey:
             user_metadata.pop("stream")
 
@@ -224,6 +255,12 @@ class MultioOutputPlugin(Output):
             raise RuntimeError("Multio server is not open, call `.open()` first.")
 
         reference_date = self.reference_date or self.context.reference_date
+        if not isinstance(reference_date, datetime):
+            raise ValueError("Reference date must be a datetime object.")
+
+        reference_date, hdate = _handle_hindcast_date(
+            reference_date, self._user_defined_metadata.hindcast_reference_date
+        )
         step = state["step"]
 
         shared_metadata = {
@@ -231,6 +268,7 @@ class MultioOutputPlugin(Output):
             "grid": str(self.metadata.grid).upper(),
             "date": int(reference_date.strftime("%Y%m%d")),  # type: ignore
             "time": int(reference_date.strftime("%H%M%S")),  # type: ignore
+            "hdate": hdate,
         }
 
         timespan = self.metadata.timestep.total_seconds() // 3600

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
@@ -56,9 +56,9 @@ class UserDefinedMetadata(BaseModel):
     """Model name, e.g. aifs-single, ..."""
     number: int | None = None
     """Ensemble number, e.g. 0,1,2"""
-    hindcast_reference_year: int | None = None
-    """Hindcast reference year, e.g. 2020
-        If set, this will be used as the year in the output metadata instead of the state reference date,
+    hindcast_reference_date: datetime | None = None
+    """Hindcast reference date, e.g. 20200101
+        If set, this will be used as the date in the output metadata instead of the state reference date,
         and the actual initial condition date will be written in the hdate key.
     """
 
@@ -73,10 +73,19 @@ class UserDefinedMetadata(BaseModel):
             raise ValueError("numberOfForecastsInEnsemble must be an integer if number is provided")
         return self
 
-    @field_validator("hindcast_reference_year")
-    def validate_hindcast_reference_year(cls, v):
-        if v is not None and (not isinstance(v, int) or len(str(v)) != 4):
-            raise ValueError("hindcast_reference_year must be a 4-digit year, e.g. 2020")
+    @field_validator("hindcast_reference_date", mode="before")
+    def validate_hindcast_reference_date(cls, v):
+        if isinstance(v, str):
+            try:
+                v = datetime.fromisoformat(v) if "-" in v else datetime(int(v[:4]), int(v[4:6]), int(v[6:8]))
+            except ValueError as e:
+                raise ValueError(
+                    "hindcast_reference_date must be an 8-digit datetime string in the format YYYYMMDD"
+                ) from e
+        elif isinstance(v, int):
+            v = datetime.fromisoformat(str(v))
+        if v is not None and not isinstance(v, datetime):
+            raise ValueError("hindcast_reference_date must be a datetime object")
         return v
 
 
@@ -97,7 +106,7 @@ class MultioMetadata(BaseModel):
     levelist: int | None = None
     """Level, e.g. 0,50,100"""
     hdate: int | None = None
-    """Hindcast initial condition date, e.g. 20200101, only used if hindcast_reference_year is provided in the user metadata"""
+    """Hindcast initial condition date, e.g. 20200101, only used if hindcast_reference_date is provided in the user metadata"""
     timespan: int | None = None
     """Time span, e.g."""
 
@@ -138,20 +147,6 @@ def _to_mars(metadata: MultioMetadata, user_metadata: UserDefinedMetadata) -> di
         mars_dict["number"] = user_metadata.number
 
     return mars_dict
-
-
-def _handle_hindcast_date(date: datetime, hindcast_reference_year: int | None) -> tuple[datetime, int | None]:
-    """Handle the date and time for the output metadata, taking into account the hindcast reference date if provided."""
-    if hindcast_reference_year is not None:
-        if date.day == 29 and date.month == 2:
-            hdate = int(f"{hindcast_reference_year}0228")
-        else:
-            hdate = int(date.strftime("%Y%m%d"))
-        # If hindcast_reference_year is provided, use it as the year of the date in the output metadata and write the actual reference date in the hdate key
-        reference_date = datetime.fromisoformat(f"{hindcast_reference_year}{date.strftime('%m%dT%H:%M:%S')}")
-        return reference_date, hdate
-    else:
-        return date, None
 
 
 class MultioOutputPlugin(Output):
@@ -209,7 +204,7 @@ class MultioOutputPlugin(Output):
 
         self._server.open_connections()
         user_metadata = self._user_defined_metadata.model_dump(exclude_none=True, by_alias=True)
-        user_metadata.pop("hindcast_reference_year")
+        user_metadata.pop("hindcast_reference_date", None)
 
         if user_metadata.get("stream") == originkey:
             user_metadata.pop("stream")
@@ -255,12 +250,20 @@ class MultioOutputPlugin(Output):
             raise RuntimeError("Multio server is not open, call `.open()` first.")
 
         reference_date = self.reference_date or self.context.reference_date
+        href_date = self._user_defined_metadata.hindcast_reference_date
+
         if not isinstance(reference_date, datetime):
             raise ValueError("Reference date must be a datetime object.")
 
-        reference_date, hdate = _handle_hindcast_date(
-            reference_date, self._user_defined_metadata.hindcast_reference_year
+        reference_date, hdate = (
+            (
+                datetime.fromisoformat(f"{href_date.strftime('%Y%m%d')}T{reference_date.strftime('%H%M%S')}"),
+                reference_date,
+            )
+            if href_date is not None
+            else (reference_date, None)
         )
+
         step = state["step"]
 
         shared_metadata = {
@@ -268,7 +271,7 @@ class MultioOutputPlugin(Output):
             "grid": str(self.metadata.grid).upper(),
             "date": int(reference_date.strftime("%Y%m%d")),  # type: ignore
             "time": int(reference_date.strftime("%H%M%S")),  # type: ignore
-            "hdate": hdate,
+            "hdate": int(hdate.strftime("%Y%m%d")) if hdate is not None else None,
         }
 
         timespan = self.metadata.timestep.total_seconds() // 3600

--- a/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/multio/multio_output.py
@@ -56,9 +56,9 @@ class UserDefinedMetadata(BaseModel):
     """Model name, e.g. aifs-single, ..."""
     number: int | None = None
     """Ensemble number, e.g. 0,1,2"""
-    hindcast_reference_date: int | None = None
-    """Hindcast reference date, e.g. 2020
-        If set, this will be used as the date in the output metadata instead of the state reference date,
+    hindcast_reference_year: int | None = None
+    """Hindcast reference year, e.g. 2020
+        If set, this will be used as the year in the output metadata instead of the state reference date,
         and the actual initial condition date will be written in the hdate key.
     """
 
@@ -73,10 +73,10 @@ class UserDefinedMetadata(BaseModel):
             raise ValueError("numberOfForecastsInEnsemble must be an integer if number is provided")
         return self
 
-    @field_validator("hindcast_reference_date")
-    def validate_hindcast_reference_date(cls, v):
+    @field_validator("hindcast_reference_year")
+    def validate_hindcast_reference_year(cls, v):
         if v is not None and (not isinstance(v, int) or len(str(v)) != 4):
-            raise ValueError("hindcast_reference_date must be a 4-digit year, e.g. 2020")
+            raise ValueError("hindcast_reference_year must be a 4-digit year, e.g. 2020")
         return v
 
 
@@ -97,7 +97,7 @@ class MultioMetadata(BaseModel):
     levelist: int | None = None
     """Level, e.g. 0,50,100"""
     hdate: int | None = None
-    """Hindcast initial condition date, e.g. 20200101, only used if hindcast_reference_date is provided in the user metadata"""
+    """Hindcast initial condition date, e.g. 20200101, only used if hindcast_reference_year is provided in the user metadata"""
     timespan: int | None = None
     """Time span, e.g."""
 
@@ -140,15 +140,15 @@ def _to_mars(metadata: MultioMetadata, user_metadata: UserDefinedMetadata) -> di
     return mars_dict
 
 
-def _handle_hindcast_date(date: datetime, hindcast_reference_date: int | None) -> tuple[datetime, int | None]:
+def _handle_hindcast_date(date: datetime, hindcast_reference_year: int | None) -> tuple[datetime, int | None]:
     """Handle the date and time for the output metadata, taking into account the hindcast reference date if provided."""
-    if hindcast_reference_date is not None:
+    if hindcast_reference_year is not None:
         if date.day == 29 and date.month == 2:
-            hdate = int(f"{hindcast_reference_date}0228")
+            hdate = int(f"{hindcast_reference_year}0228")
         else:
             hdate = int(date.strftime("%Y%m%d"))
-        # If hindcast_reference_date is provided, use it as the year of the date in the output metadata and write the actual reference date in the hdate key
-        reference_date = datetime.fromisoformat(f"{hindcast_reference_date}{date.strftime('%m%dT%H:%M:%S')}")
+        # If hindcast_reference_year is provided, use it as the year of the date in the output metadata and write the actual reference date in the hdate key
+        reference_date = datetime.fromisoformat(f"{hindcast_reference_year}{date.strftime('%m%dT%H:%M:%S')}")
         return reference_date, hdate
     else:
         return date, None
@@ -209,7 +209,7 @@ class MultioOutputPlugin(Output):
 
         self._server.open_connections()
         user_metadata = self._user_defined_metadata.model_dump(exclude_none=True, by_alias=True)
-        user_metadata.pop("hindcast_reference_date")
+        user_metadata.pop("hindcast_reference_year")
 
         if user_metadata.get("stream") == originkey:
             user_metadata.pop("stream")
@@ -259,7 +259,7 @@ class MultioOutputPlugin(Output):
             raise ValueError("Reference date must be a datetime object.")
 
         reference_date, hdate = _handle_hindcast_date(
-            reference_date, self._user_defined_metadata.hindcast_reference_date
+            reference_date, self._user_defined_metadata.hindcast_reference_year
         )
         step = state["step"]
 

--- a/inference/tests/multio/test_hdate.py
+++ b/inference/tests/multio/test_hdate.py
@@ -10,9 +10,9 @@
 """Tests for the hindcast date (hdate) logic in MultioOutputPlugin.
 
 The hdate mechanism swaps the year of the reference date with a
-``hindcast_reference_date`` year, writing the original date into the
+``hindcast_reference_year`` year, writing the original date into the
 ``hdate`` metadata key.  For example, given reference_date=2025-06-10
-and hindcast_reference_date=2026:
+and hindcast_reference_year=2026:
 
     date  -> 20260610   (year replaced)
     hdate -> 20250610   (original date preserved)
@@ -44,7 +44,7 @@ from anemoi.plugins.ecmwf.inference.multio.multio_output import _handle_hindcast
 
 
 class TestUserDefinedMetadataHdate:
-    """Tests for hindcast_reference_date on UserDefinedMetadata."""
+    """Tests for hindcast_reference_year on UserDefinedMetadata."""
 
     BASE_KWARGS = {
         "stream": "oper",
@@ -54,22 +54,22 @@ class TestUserDefinedMetadataHdate:
     }
 
     def test_valid_hindcast_year(self):
-        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date=2026)
-        assert meta.hindcast_reference_date == 2026
+        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_year=2026)
+        assert meta.hindcast_reference_year == 2026
 
     def test_hindcast_none_accepted(self):
-        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date=None)
-        assert meta.hindcast_reference_date is None
+        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_year=None)
+        assert meta.hindcast_reference_year is None
 
     def test_hindcast_year_too_short(self):
         """A 2-digit year should not be accepted as a valid hindcast year."""
         with pytest.raises(ValueError):
-            UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date=26)
+            UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_year=26)
 
     def test_hindcast_year_full_date_rejected_by_length(self):
         """A full YYYYMMDD int (8 digits) should be caught by the 4-digit check."""
         with pytest.raises(ValueError):
-            UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date=20260610)
+            UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_year=20260610)
 
 
 # ---------------------------------------------------------------------------
@@ -102,7 +102,7 @@ class TestHandleTime:
         assert hdate == 20191231
 
     def test_none_hindcast_returns_original(self):
-        """When hindcast_reference_date is None, date is unchanged and hdate is None."""
+        """When hindcast_reference_year is None, date is unchanged and hdate is None."""
         original = datetime(2025, 6, 10, 12, 0, 0)
         ref_date, hdate = _handle_hindcast_date(original, None)
         assert ref_date is original
@@ -155,7 +155,7 @@ def _make_state(ref_date: datetime, step_hours: int = 6) -> State:
 
 
 def _make_hdate_output_override(hindcast_year: int) -> dict:
-    """Build an output override dict with hindcast_reference_date set."""
+    """Build an output override dict with hindcast_reference_year set."""
     return {
         "multio": {
             "path": "/dev/null",
@@ -164,7 +164,7 @@ def _make_hdate_output_override(hindcast_year: int) -> dict:
             "class": "ai",
             "type": "pf",
             "model": "test",
-            "hindcast_reference_date": hindcast_year,
+            "hindcast_reference_year": hindcast_year,
             "number": 0,
             "numberOfForecastsInEnsemble": 51,
         }
@@ -262,7 +262,7 @@ def test_write_step_hdate_preserves_time(mock_multio_server):
 
 @fake_checkpoints
 def test_write_step_no_hdate_when_not_configured(mock_multio_server):
-    """When hindcast_reference_date is None, hdate should not appear in metadata."""
+    """When hindcast_reference_year is None, hdate should not appear in metadata."""
     state = _make_state(datetime(2025, 6, 10))
     calls = _create_output_and_write(mock_multio_server, state)
 

--- a/inference/tests/multio/test_hdate.py
+++ b/inference/tests/multio/test_hdate.py
@@ -9,21 +9,11 @@
 
 """Tests for the hindcast date (hdate) logic in MultioOutputPlugin.
 
-The hdate mechanism swaps the year of the reference date with a
-``hindcast_reference_year`` year, writing the original date into the
-``hdate`` metadata key.  For example, given reference_date=2025-06-10
-and hindcast_reference_year=2026:
-
-    date  -> 20260610   (year replaced)
-    hdate -> 20250610   (original date preserved)
-
-Special case: if the reference date is Feb 29, hdate is recorded as
-YYYY0228 (clamped to Feb 28) regardless of whether the hindcast year
-is a leap year.
+When hindcast_reference_date is set, it replaces the date in output metadata,
+and the original reference date is preserved as the hdate key.
 """
 
 from datetime import datetime
-from datetime import timedelta
 from pathlib import Path
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -36,7 +26,8 @@ from anemoi.inference.testing.mock_checkpoint import MockRunConfiguration
 from anemoi.inference.types import State
 from anemoi.plugins.ecmwf.inference.multio import MultioOutputPlugin
 from anemoi.plugins.ecmwf.inference.multio.multio_output import UserDefinedMetadata
-from anemoi.plugins.ecmwf.inference.multio.multio_output import _handle_hindcast_date
+
+CONFIGS_DIR = Path(__file__).parent / "configs"
 
 # ---------------------------------------------------------------------------
 # UserDefinedMetadata validation
@@ -44,7 +35,7 @@ from anemoi.plugins.ecmwf.inference.multio.multio_output import _handle_hindcast
 
 
 class TestUserDefinedMetadataHdate:
-    """Tests for hindcast_reference_year on UserDefinedMetadata."""
+    """Tests for hindcast_reference_date on UserDefinedMetadata."""
 
     BASE_KWARGS = {
         "stream": "oper",
@@ -53,129 +44,46 @@ class TestUserDefinedMetadataHdate:
         "expver": "1",
     }
 
-    def test_valid_hindcast_year(self):
-        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_year=2026)
-        assert meta.hindcast_reference_year == 2026
+    def test_accepts_datetime(self):
+        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date=datetime(2026, 1, 1))
+        assert meta.hindcast_reference_date == datetime(2026, 1, 1)
 
-    def test_hindcast_none_accepted(self):
-        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_year=None)
-        assert meta.hindcast_reference_year is None
+    def test_accepts_none(self):
+        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date=None)
+        assert meta.hindcast_reference_date is None
 
-    def test_hindcast_year_too_short(self):
-        """A 2-digit year should not be accepted as a valid hindcast year."""
+    def test_accepts_yyyymmdd_string(self):
+        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date="20260610")
+        assert meta.hindcast_reference_date == datetime(2026, 6, 10)
+
+    def test_accepts_yyyymmdd_int(self):
+        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date=20260610)
+        assert meta.hindcast_reference_date == datetime(2026, 6, 10)
+
+    def test_rejects_short_string(self):
         with pytest.raises(ValueError):
-            UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_year=26)
-
-    def test_hindcast_year_full_date_rejected_by_length(self):
-        """A full YYYYMMDD int (8 digits) should be caught by the 4-digit check."""
-        with pytest.raises(ValueError):
-            UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_year=20260610)
+            UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date="26")
 
 
 # ---------------------------------------------------------------------------
-# _handle_hindcast_date unit tests
+# Fixtures
 # ---------------------------------------------------------------------------
 
 
-class TestHandleTime:
-    """Direct tests for the _handle_hindcast_date function."""
+@pytest.fixture
+def mock_multio_server():
+    """Mock the MultIO server so write_field calls can be inspected."""
+    mocked_server = MagicMock()
+    mocked_server.write_field = MagicMock()
+    mocked_server.flush = MagicMock()
 
-    def test_basic_swap(self):
-        """Year is replaced in date, original date preserved as hdate."""
-        ref_date, hdate = _handle_hindcast_date(datetime(2025, 6, 10), 2026)
-        assert ref_date == datetime(2026, 6, 10)
-        assert hdate == 20250610
-
-    def test_preserves_time_component(self):
-        ref_date, hdate = _handle_hindcast_date(datetime(2025, 6, 10, 12, 0, 0), 2026)
-        assert ref_date == datetime(2026, 6, 10, 12, 0, 0)
-        assert hdate == 20250610
-
-    def test_different_year_gap(self):
-        ref_date, hdate = _handle_hindcast_date(datetime(2023, 3, 15, 6, 0, 0), 2030)
-        assert ref_date == datetime(2030, 3, 15, 6, 0, 0)
-        assert hdate == 20230315
-
-    def test_year_end_boundary(self):
-        ref_date, hdate = _handle_hindcast_date(datetime(2019, 12, 31, 18, 30, 0), 2025)
-        assert ref_date == datetime(2025, 12, 31, 18, 30, 0)
-        assert hdate == 20191231
-
-    def test_none_hindcast_returns_original(self):
-        """When hindcast_reference_year is None, date is unchanged and hdate is None."""
-        original = datetime(2025, 6, 10, 12, 0, 0)
-        ref_date, hdate = _handle_hindcast_date(original, None)
-        assert ref_date is original
-        assert hdate is None
-
-    # --- Feb 29 special case: hdate clamped to 0228 ---
-
-    def test_feb29_to_leap_year_hdate_clamped(self):
-        """Feb 29 reference date: hdate recorded as YYYY0228, date swapped normally."""
-        ref_date, hdate = _handle_hindcast_date(datetime(2024, 2, 29), 2028)
-        assert ref_date == datetime(2028, 2, 29)
-        assert hdate == 20280228, f"Expected hdate clamped to 0228, got {hdate}"
-
-    def test_feb29_to_non_leap_year_hdate_clamped(self):
-        """Feb 29 reference date with non-leap hindcast year: hdate is YYYY0228.
-
-        The date swap will raise because Feb 29 does not exist in a non-leap year.
-        """
-        with pytest.raises(ValueError):
-            _handle_hindcast_date(datetime(2024, 2, 29), 2025)
-
-    def test_feb28_not_affected_by_clamp(self):
-        """Feb 28 should not trigger the Feb 29 special case."""
-        ref_date, hdate = _handle_hindcast_date(datetime(2025, 2, 28), 2026)
-        assert ref_date == datetime(2026, 2, 28)
-        assert hdate == 20250228
+    with patch("anemoi.plugins.ecmwf.inference.multio.MultioOutputPlugin.open") as mock_open:
+        mock_open.side_effect = lambda state: setattr(MultioOutputPlugin, "_server", mocked_server)
+        yield mocked_server
 
 
-# ---------------------------------------------------------------------------
-# Helpers and fixtures for integration tests
-# ---------------------------------------------------------------------------
-
-STATE_NPOINTS = 50
-CONFIGS_DIR = Path(__file__).parent / "configs"
-
-
-def _make_state(ref_date: datetime, step_hours: int = 6) -> State:
-    """Build a mock state with the given reference date."""
-    return {
-        "latitudes": np.random.uniform(-90, 90, size=STATE_NPOINTS),
-        "longitudes": np.random.uniform(-180, 180, size=STATE_NPOINTS),
-        "fields": {
-            "2t": np.random.uniform(250, 310, size=STATE_NPOINTS),
-            "msl": np.random.uniform(500, 1500, size=STATE_NPOINTS),
-            "tp": np.random.uniform(0, 10, size=STATE_NPOINTS),
-        },
-        "date": ref_date,
-        "step": timedelta(hours=step_hours),
-    }
-
-
-def _make_hdate_output_override(hindcast_year: int) -> dict:
-    """Build an output override dict with hindcast_reference_year set."""
-    return {
-        "multio": {
-            "path": "/dev/null",
-            "stream": "eefh",
-            "expver": "9999",
-            "class": "ai",
-            "type": "pf",
-            "model": "test",
-            "hindcast_reference_year": hindcast_year,
-            "number": 0,
-            "numberOfForecastsInEnsemble": 51,
-        }
-    }
-
-
-def _create_output_and_write(mock_server, state: State, output_override: dict | None = None):
-    """Create a runner+output from the test config, open, and write_step.
-
-    Returns the list of (metadata, field) tuples from write_field calls.
-    """
+def _run_write_step(mock_server, state: State, output_override: dict | None = None) -> list:
+    """Create runner, open output, write one step, return write_field call args."""
     overrides = dict(runner="no-model", device="cpu", input="dummy")
     if output_override is not None:
         overrides["output"] = output_override
@@ -193,66 +101,66 @@ def _create_output_and_write(mock_server, state: State, output_override: dict | 
     assert output._server is mock_server
 
     output.write_step(state)
-
     return [call.args for call in mock_server.write_field.call_args_list]
 
 
-@pytest.fixture
-def mock_multio_server():
-    mocked_server = MagicMock()
-    mocked_server.write_field = MagicMock()
-    mocked_server.flush = MagicMock()
-
-    with patch("anemoi.plugins.ecmwf.inference.multio.MultioOutputPlugin.open") as mock_open:
-        mock_open.side_effect = lambda state: setattr(MultioOutputPlugin, "_server", mocked_server)
-        yield mocked_server
+def _hdate_output_override(hindcast_reference_date: str) -> dict:
+    return {
+        "multio": {
+            "path": "/dev/null",
+            "stream": "eefh",
+            "expver": "9999",
+            "class": "ai",
+            "type": "pf",
+            "model": "test",
+            "hindcast_reference_date": hindcast_reference_date,
+            "number": 0,
+            "numberOfForecastsInEnsemble": 51,
+        }
+    }
 
 
 # ---------------------------------------------------------------------------
-# Integration: write_step date/hdate through the real plugin code
+# Integration tests: write_step with hdate
 # ---------------------------------------------------------------------------
 
 
 @fake_checkpoints
 @pytest.mark.parametrize(
-    "ref_date, hindcast_year, expected_date, expected_hdate",
+    "ref_date, hindcast_reference_date, expected_date, expected_hdate",
     [
-        # Basic: year swapped, original preserved as hdate
-        (datetime(2025, 6, 10), 2026, 20260610, 20250610),
-        # Different year gap
-        (datetime(2023, 3, 15), 2030, 20300315, 20230315),
-        # Year-end boundary
-        (datetime(2019, 12, 31), 2025, 20251231, 20191231),
-        # Leap day into another leap year: hdate clamped to 0228
-        (datetime(2024, 2, 29), 2028, 20280229, 20280228),
+        (datetime(2025, 6, 10), "20260610", 20260610, 20250610),
+        (datetime(2023, 3, 15), "20300315", 20300315, 20230315),
+        (datetime(2019, 12, 31), "20251231", 20251231, 20191231),
+        (datetime(2024, 2, 28), "20280229", 20280229, 20240228),
+        (datetime(2022, 2, 28), "20250228", 20250228, 20220228),
     ],
-    ids=["basic-swap", "different-years", "year-end", "leap-to-leap-clamped"],
+    ids=["basic", "different-years", "year-end", "leap-target", "non-leap-target"],
 )
-def test_write_step_hdate_swap(mock_multio_server, ref_date, hindcast_year, expected_date, expected_hdate):
-    """write_step should swap the year and preserve the original date as hdate."""
-    state = _make_state(ref_date)
-    calls = _create_output_and_write(
-        mock_multio_server,
-        state,
-        output_override=_make_hdate_output_override(hindcast_year),
-    )
+def test_write_step_sets_date_and_hdate(
+    mock_multio_server,
+    mock_state,
+    ref_date,
+    hindcast_reference_date,
+    expected_date,
+    expected_hdate,
+):
+    """When hindcast_reference_date is configured, date is replaced and hdate is the original."""
+    mock_state["date"] = ref_date
+    calls = _run_write_step(mock_multio_server, mock_state, _hdate_output_override(hindcast_reference_date))
 
-    assert len(calls) > 0, "Expected at least one write_field call"
+    assert len(calls) > 0
     for metadata, field in calls:
-        assert metadata["date"] == expected_date, f"Expected date {expected_date}, got {metadata['date']}"
-        assert metadata["hdate"] == expected_hdate, f"Expected hdate {expected_hdate}, got {metadata['hdate']}"
+        assert metadata["date"] == expected_date
+        assert metadata["hdate"] == expected_hdate
         assert isinstance(field, np.ndarray)
 
 
 @fake_checkpoints
-def test_write_step_hdate_preserves_time(mock_multio_server):
-    """The time component should survive the year swap unchanged."""
-    state = _make_state(datetime(2025, 6, 10, 12, 0, 0))
-    calls = _create_output_and_write(
-        mock_multio_server,
-        state,
-        output_override=_make_hdate_output_override(2026),
-    )
+def test_write_step_preserves_time(mock_multio_server, mock_state):
+    """The time component from the original reference date is preserved."""
+    mock_state["date"] = datetime(2025, 6, 10, 12, 0, 0)
+    calls = _run_write_step(mock_multio_server, mock_state, _hdate_output_override("20260610"))
 
     for metadata, _ in calls:
         assert metadata["date"] == 20260610
@@ -261,25 +169,23 @@ def test_write_step_hdate_preserves_time(mock_multio_server):
 
 
 @fake_checkpoints
-def test_write_step_no_hdate_when_not_configured(mock_multio_server):
-    """When hindcast_reference_year is None, hdate should not appear in metadata."""
-    state = _make_state(datetime(2025, 6, 10))
-    calls = _create_output_and_write(mock_multio_server, state)
+def test_write_step_no_hdate_without_config(mock_multio_server, mock_state):
+    """When hindcast_reference_date is not set, hdate is absent from metadata."""
+    calls = _run_write_step(mock_multio_server, mock_state)
 
     for metadata, _ in calls:
-        assert "hdate" not in metadata, f"hdate should not be present when not configured, got {metadata}"
-        assert metadata["date"] == 20250610
+        assert "hdate" not in metadata
+        assert metadata["date"] == 20200101
 
 
 @fake_checkpoints
-def test_write_step_step_field_unaffected_by_hdate(mock_multio_server):
-    """The forecast step in metadata should not be affected by the hdate swap."""
-    state = _make_state(datetime(2025, 6, 10), step_hours=24)
-    calls = _create_output_and_write(
-        mock_multio_server,
-        state,
-        output_override=_make_hdate_output_override(2026),
-    )
+def test_write_step_step_unaffected_by_hdate(mock_multio_server, mock_state):
+    """Forecast step in metadata is independent of hdate logic."""
+    from datetime import timedelta
+
+    mock_state["date"] = datetime(2025, 6, 10)
+    mock_state["step"] = timedelta(hours=24)
+    calls = _run_write_step(mock_multio_server, mock_state, _hdate_output_override("20260610"))
 
     for metadata, _ in calls:
         assert metadata["step"] == 24

--- a/inference/tests/multio/test_hdate.py
+++ b/inference/tests/multio/test_hdate.py
@@ -1,0 +1,287 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Tests for the hindcast date (hdate) logic in MultioOutputPlugin.
+
+The hdate mechanism swaps the year of the reference date with a
+``hindcast_reference_date`` year, writing the original date into the
+``hdate`` metadata key.  For example, given reference_date=2025-06-10
+and hindcast_reference_date=2026:
+
+    date  -> 20260610   (year replaced)
+    hdate -> 20250610   (original date preserved)
+
+Special case: if the reference date is Feb 29, hdate is recorded as
+YYYY0228 (clamped to Feb 28) regardless of whether the hindcast year
+is a leap year.
+"""
+
+from datetime import datetime
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from anemoi.inference.runners import create_runner
+from anemoi.inference.testing import fake_checkpoints
+from anemoi.inference.testing.mock_checkpoint import MockRunConfiguration
+from anemoi.inference.types import State
+from anemoi.plugins.ecmwf.inference.multio import MultioOutputPlugin
+from anemoi.plugins.ecmwf.inference.multio.multio_output import UserDefinedMetadata
+from anemoi.plugins.ecmwf.inference.multio.multio_output import _handle_hindcast_date
+
+# ---------------------------------------------------------------------------
+# UserDefinedMetadata validation
+# ---------------------------------------------------------------------------
+
+
+class TestUserDefinedMetadataHdate:
+    """Tests for hindcast_reference_date on UserDefinedMetadata."""
+
+    BASE_KWARGS = {
+        "stream": "oper",
+        "type": "fc",
+        "class": "od",
+        "expver": "1",
+    }
+
+    def test_valid_hindcast_year(self):
+        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date=2026)
+        assert meta.hindcast_reference_date == 2026
+
+    def test_hindcast_none_accepted(self):
+        meta = UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date=None)
+        assert meta.hindcast_reference_date is None
+
+    def test_hindcast_year_too_short(self):
+        """A 2-digit year should not be accepted as a valid hindcast year."""
+        with pytest.raises(ValueError):
+            UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date=26)
+
+    def test_hindcast_year_full_date_rejected_by_length(self):
+        """A full YYYYMMDD int (8 digits) should be caught by the 4-digit check."""
+        with pytest.raises(ValueError):
+            UserDefinedMetadata(**self.BASE_KWARGS, hindcast_reference_date=20260610)
+
+
+# ---------------------------------------------------------------------------
+# _handle_hindcast_date unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleTime:
+    """Direct tests for the _handle_hindcast_date function."""
+
+    def test_basic_swap(self):
+        """Year is replaced in date, original date preserved as hdate."""
+        ref_date, hdate = _handle_hindcast_date(datetime(2025, 6, 10), 2026)
+        assert ref_date == datetime(2026, 6, 10)
+        assert hdate == 20250610
+
+    def test_preserves_time_component(self):
+        ref_date, hdate = _handle_hindcast_date(datetime(2025, 6, 10, 12, 0, 0), 2026)
+        assert ref_date == datetime(2026, 6, 10, 12, 0, 0)
+        assert hdate == 20250610
+
+    def test_different_year_gap(self):
+        ref_date, hdate = _handle_hindcast_date(datetime(2023, 3, 15, 6, 0, 0), 2030)
+        assert ref_date == datetime(2030, 3, 15, 6, 0, 0)
+        assert hdate == 20230315
+
+    def test_year_end_boundary(self):
+        ref_date, hdate = _handle_hindcast_date(datetime(2019, 12, 31, 18, 30, 0), 2025)
+        assert ref_date == datetime(2025, 12, 31, 18, 30, 0)
+        assert hdate == 20191231
+
+    def test_none_hindcast_returns_original(self):
+        """When hindcast_reference_date is None, date is unchanged and hdate is None."""
+        original = datetime(2025, 6, 10, 12, 0, 0)
+        ref_date, hdate = _handle_hindcast_date(original, None)
+        assert ref_date is original
+        assert hdate is None
+
+    # --- Feb 29 special case: hdate clamped to 0228 ---
+
+    def test_feb29_to_leap_year_hdate_clamped(self):
+        """Feb 29 reference date: hdate recorded as YYYY0228, date swapped normally."""
+        ref_date, hdate = _handle_hindcast_date(datetime(2024, 2, 29), 2028)
+        assert ref_date == datetime(2028, 2, 29)
+        assert hdate == 20280228, f"Expected hdate clamped to 0228, got {hdate}"
+
+    def test_feb29_to_non_leap_year_hdate_clamped(self):
+        """Feb 29 reference date with non-leap hindcast year: hdate is YYYY0228.
+
+        The date swap will raise because Feb 29 does not exist in a non-leap year.
+        """
+        with pytest.raises(ValueError):
+            _handle_hindcast_date(datetime(2024, 2, 29), 2025)
+
+    def test_feb28_not_affected_by_clamp(self):
+        """Feb 28 should not trigger the Feb 29 special case."""
+        ref_date, hdate = _handle_hindcast_date(datetime(2025, 2, 28), 2026)
+        assert ref_date == datetime(2026, 2, 28)
+        assert hdate == 20250228
+
+
+# ---------------------------------------------------------------------------
+# Helpers and fixtures for integration tests
+# ---------------------------------------------------------------------------
+
+STATE_NPOINTS = 50
+CONFIGS_DIR = Path(__file__).parent / "configs"
+
+
+def _make_state(ref_date: datetime, step_hours: int = 6) -> State:
+    """Build a mock state with the given reference date."""
+    return {
+        "latitudes": np.random.uniform(-90, 90, size=STATE_NPOINTS),
+        "longitudes": np.random.uniform(-180, 180, size=STATE_NPOINTS),
+        "fields": {
+            "2t": np.random.uniform(250, 310, size=STATE_NPOINTS),
+            "msl": np.random.uniform(500, 1500, size=STATE_NPOINTS),
+            "tp": np.random.uniform(0, 10, size=STATE_NPOINTS),
+        },
+        "date": ref_date,
+        "step": timedelta(hours=step_hours),
+    }
+
+
+def _make_hdate_output_override(hindcast_year: int) -> dict:
+    """Build an output override dict with hindcast_reference_date set."""
+    return {
+        "multio": {
+            "path": "/dev/null",
+            "stream": "eefh",
+            "expver": "9999",
+            "class": "ai",
+            "type": "pf",
+            "model": "test",
+            "hindcast_reference_date": hindcast_year,
+            "number": 0,
+            "numberOfForecastsInEnsemble": 51,
+        }
+    }
+
+
+def _create_output_and_write(mock_server, state: State, output_override: dict | None = None):
+    """Create a runner+output from the test config, open, and write_step.
+
+    Returns the list of (metadata, field) tuples from write_field calls.
+    """
+    overrides = dict(runner="no-model", device="cpu", input="dummy")
+    if output_override is not None:
+        overrides["output"] = output_override
+
+    config = MockRunConfiguration.load(
+        str((CONFIGS_DIR / "multio.yaml").absolute()),
+        overrides=overrides,
+    )
+
+    runner = create_runner(config)
+    output = runner.create_output("data", runner.tensor_handlers["data"].metadata)
+
+    output.open(state)
+    output.reference_date = state["date"]
+    assert output._server is mock_server
+
+    output.write_step(state)
+
+    return [call.args for call in mock_server.write_field.call_args_list]
+
+
+@pytest.fixture
+def mock_multio_server():
+    mocked_server = MagicMock()
+    mocked_server.write_field = MagicMock()
+    mocked_server.flush = MagicMock()
+
+    with patch("anemoi.plugins.ecmwf.inference.multio.MultioOutputPlugin.open") as mock_open:
+        mock_open.side_effect = lambda state: setattr(MultioOutputPlugin, "_server", mocked_server)
+        yield mocked_server
+
+
+# ---------------------------------------------------------------------------
+# Integration: write_step date/hdate through the real plugin code
+# ---------------------------------------------------------------------------
+
+
+@fake_checkpoints
+@pytest.mark.parametrize(
+    "ref_date, hindcast_year, expected_date, expected_hdate",
+    [
+        # Basic: year swapped, original preserved as hdate
+        (datetime(2025, 6, 10), 2026, 20260610, 20250610),
+        # Different year gap
+        (datetime(2023, 3, 15), 2030, 20300315, 20230315),
+        # Year-end boundary
+        (datetime(2019, 12, 31), 2025, 20251231, 20191231),
+        # Leap day into another leap year: hdate clamped to 0228
+        (datetime(2024, 2, 29), 2028, 20280229, 20280228),
+    ],
+    ids=["basic-swap", "different-years", "year-end", "leap-to-leap-clamped"],
+)
+def test_write_step_hdate_swap(mock_multio_server, ref_date, hindcast_year, expected_date, expected_hdate):
+    """write_step should swap the year and preserve the original date as hdate."""
+    state = _make_state(ref_date)
+    calls = _create_output_and_write(
+        mock_multio_server,
+        state,
+        output_override=_make_hdate_output_override(hindcast_year),
+    )
+
+    assert len(calls) > 0, "Expected at least one write_field call"
+    for metadata, field in calls:
+        assert metadata["date"] == expected_date, f"Expected date {expected_date}, got {metadata['date']}"
+        assert metadata["hdate"] == expected_hdate, f"Expected hdate {expected_hdate}, got {metadata['hdate']}"
+        assert isinstance(field, np.ndarray)
+
+
+@fake_checkpoints
+def test_write_step_hdate_preserves_time(mock_multio_server):
+    """The time component should survive the year swap unchanged."""
+    state = _make_state(datetime(2025, 6, 10, 12, 0, 0))
+    calls = _create_output_and_write(
+        mock_multio_server,
+        state,
+        output_override=_make_hdate_output_override(2026),
+    )
+
+    for metadata, _ in calls:
+        assert metadata["date"] == 20260610
+        assert metadata["hdate"] == 20250610
+        assert metadata["time"] == 120000
+
+
+@fake_checkpoints
+def test_write_step_no_hdate_when_not_configured(mock_multio_server):
+    """When hindcast_reference_date is None, hdate should not appear in metadata."""
+    state = _make_state(datetime(2025, 6, 10))
+    calls = _create_output_and_write(mock_multio_server, state)
+
+    for metadata, _ in calls:
+        assert "hdate" not in metadata, f"hdate should not be present when not configured, got {metadata}"
+        assert metadata["date"] == 20250610
+
+
+@fake_checkpoints
+def test_write_step_step_field_unaffected_by_hdate(mock_multio_server):
+    """The forecast step in metadata should not be affected by the hdate swap."""
+    state = _make_state(datetime(2025, 6, 10), step_hours=24)
+    calls = _create_output_and_write(
+        mock_multio_server,
+        state,
+        output_override=_make_hdate_output_override(2026),
+    )
+
+    for metadata, _ in calls:
+        assert metadata["step"] == 24
+        assert metadata["date"] == 20260610
+        assert metadata["hdate"] == 20250610


### PR DESCRIPTION
### Description
This pull request introduces support for handling hindcast reference dates ("hdate") in the `MultioOutputPlugin` for ECMWF inference output. The main feature allows users to specify a `hindcast_reference_date` that swaps the year in the output metadata while preserving the original date in a new `hdate` field. 

**Hindcast date support and metadata changes:**

* Added a new optional `hindcast_reference_date` field to the `UserDefinedMetadata` model, with validation to ensure it is a 4-digit year. [[1]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cR59-R64) [[2]](diffhunk://#diff-ce9036617d83382bbaf247ec6c3b15292a8dc51a0bf1a82a169bbf611110469cR76-R81)
* Modified the `MultioMetadata` model to include a new `hdate` field, which records the original initial condition date when a hindcast reference date is used.
* Implemented the `_handle_hindcast_date` function to swap the year in the output date with the hindcast reference year and handle special cases such as February 29th (clamped to February 28th if necessary).

**Testing and validation:**

* Added a new test module `test_hdate.py` with unit and integration tests covering validation of `hindcast_reference_date`, correct swapping and clamping of dates, and the behavior of the plugin when the hindcast feature is enabled or omitted.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
