### PR TITLE
feat: add `compute_tv` plugin for anemoi inference

### DIFF
--- a/inference/README.md
+++ b/inference/README.md
@@ -12,6 +12,7 @@ This package includes all plugins developed for anemoi inference developed by EC
 | `mir`     | Use mir to create grib templates   |
 | `regrid`  | Use `earthkit-regrid` to preprocess|
 | `dynamics`| Use `earthkit-regrid` to preprocess|
+| `compute_tv`| Replace `T` with virtual temperature `Tv` on model levels |
 
 See the underlying code for a more detailed `README`.
 

--- a/inference/pyproject.toml
+++ b/inference/pyproject.toml
@@ -70,6 +70,7 @@ entry-points."anemoi.inference.outputs"."multio" = "anemoi.plugins.ecmwf.inferen
 entry-points."anemoi.inference.outputs"."multio.fdb" = "anemoi.plugins.ecmwf.inference.multio.multio_output:MultioOutputFDBPlugin"
 entry-points."anemoi.inference.outputs"."multio.grib" = "anemoi.plugins.ecmwf.inference.multio.multio_output:MultioOutputGribPlugin"
 entry-points."anemoi.inference.outputs"."multio.plan" = "anemoi.plugins.ecmwf.inference.multio.multio_output:MultioOutputPlanPlugin"
+entry-points."anemoi.inference.post_processors"."compute_tv" = "anemoi.plugins.ecmwf.inference.compute_tv:ComputeTvPlugin"
 entry-points."anemoi.inference.pre_processors"."array_overlay" = "anemoi.plugins.ecmwf.inference.dynamics:ArrayOverlayPlugin"
 entry-points."anemoi.inference.pre_processors"."modify_value" = "anemoi.plugins.ecmwf.inference.dynamics:ModifyValuePlugin"
 entry-points."anemoi.inference.pre_processors"."regrid" = "anemoi.plugins.ecmwf.inference.regrid:RegridPreprocessor"

--- a/inference/src/anemoi/plugins/ecmwf/inference/compute_tv/README.md
+++ b/inference/src/anemoi/plugins/ecmwf/inference/compute_tv/README.md
@@ -1,0 +1,44 @@
+# An anemoi-inference virtual temperature post-processor
+
+Replace temperature `T` with virtual temperature `Tv` on model levels.
+
+For every temperature field named `t_<level>` for which a matching specific
+humidity field `q_<level>` exists, the temperature is replaced by
+
+```text
+Tv = T * (1 + 0.61 * q)
+```
+
+Temperature fields without a matching humidity field are left unchanged.
+
+## Install
+
+This post-processor has no extra dependencies beyond `anemoi-inference`, so it is
+available with a plain install of the package:
+
+```bash
+pip install anemoi-plugins-ecmwf-inference
+```
+
+## Usage
+
+This post-processor can be used like any other for anemoi inference. Below is an
+example config.
+
+```yaml
+checkpoint:
+  huggingface: ecmwf/aifs-single-1.0
+
+date: 2020-01-01
+
+input: mars
+
+post_processors:
+  - compute_tv
+```
+
+To run, just like any other
+
+```bash
+anemoi-inference run config.yaml
+```

--- a/inference/src/anemoi/plugins/ecmwf/inference/compute_tv/__init__.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/compute_tv/__init__.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Anemoi Inference Virtual Temperature Post-Processor Plugin"""
+
+from .compute_tv import ComputeTvPlugin as ComputeTvPlugin

--- a/inference/src/anemoi/plugins/ecmwf/inference/compute_tv/compute_tv.py
+++ b/inference/src/anemoi/plugins/ecmwf/inference/compute_tv/compute_tv.py
@@ -1,0 +1,54 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from anemoi.inference.processor import Processor
+from anemoi.inference.types import State
+
+
+class ComputeTvPlugin(Processor):
+    """Replace temperature ``T`` with virtual temperature ``Tv`` on model levels.
+
+    For every temperature field named ``t_<level>`` for which a matching specific
+    humidity field ``q_<level>`` exists, the temperature is replaced in place by the
+    virtual temperature::
+
+        Tv = T * (1 + 0.61 * q)
+
+    Example
+    -------
+    ```yaml
+    post_processors:
+        - compute_tv
+    ```
+    """
+
+    def process(self, state: State) -> State:
+        """Replace T with Tv = T*(1 + 0.61*q) for each model level.
+
+        Parameters
+        ----------
+        state : State
+            The state dictionary.
+
+        Returns
+        -------
+        State
+            The state dictionary with temperature fields replaced by virtual
+            temperature where a matching humidity field is available.
+        """
+        state = state.copy()
+        fields = state["fields"].copy()
+        for key in list(fields):
+            if key.startswith("t_"):
+                lev = key[2:]
+                q_key = f"q_{lev}"
+                if q_key in fields:
+                    fields[key] = fields[key] * (1.0 + 0.61 * fields[q_key])
+        state["fields"] = fields
+        return state

--- a/inference/tests/compute_tv/test_compute_tv.py
+++ b/inference/tests/compute_tv/test_compute_tv.py
@@ -1,0 +1,81 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+from datetime import datetime
+from datetime import timedelta
+from typing import cast
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from anemoi.inference.context import Context
+from anemoi.inference.metadata import Metadata
+from anemoi.inference.types import State
+from anemoi.plugins.ecmwf.inference.compute_tv.compute_tv import ComputeTvPlugin
+
+NPOINTS = 50
+
+
+@pytest.fixture
+def mock_state() -> State:
+    """State with temperature/humidity on levels plus an unrelated field."""
+    return {
+        "latitudes": np.random.uniform(-90, 90, size=NPOINTS),
+        "longitudes": np.random.uniform(-180, 180, size=NPOINTS),
+        "fields": {
+            "t_850": np.random.uniform(250, 310, size=NPOINTS),
+            "q_850": np.random.uniform(0, 0.02, size=NPOINTS),
+            "t_500": np.random.uniform(230, 290, size=NPOINTS),
+            "q_500": np.random.uniform(0, 0.02, size=NPOINTS),
+            "t_100": np.random.uniform(200, 250, size=NPOINTS),  # no matching q
+            "msl": np.random.uniform(500, 1500, size=NPOINTS),
+        },
+        "date": datetime(2020, 1, 1, 0, 0),
+        "step": timedelta(hours=6),
+    }
+
+
+def _make_processor() -> ComputeTvPlugin:
+    context = cast(Context, MagicMock())
+    metadata = cast(Metadata, MagicMock())
+    return ComputeTvPlugin(context=context, metadata=metadata)
+
+
+def test_compute_tv_replaces_matched_levels(mock_state: State):
+    original = {k: v.copy() for k, v in mock_state["fields"].items()}
+    processor = _make_processor()
+
+    new_state = processor.process(mock_state)
+
+    for lev in ("850", "500"):
+        expected = original[f"t_{lev}"] * (1.0 + 0.61 * original[f"q_{lev}"])
+        np.testing.assert_allclose(new_state["fields"][f"t_{lev}"], expected)
+
+
+def test_compute_tv_leaves_unmatched_fields_untouched(mock_state: State):
+    original = {k: v.copy() for k, v in mock_state["fields"].items()}
+    processor = _make_processor()
+
+    new_state = processor.process(mock_state)
+
+    # temperature without a matching humidity field is unchanged
+    np.testing.assert_array_equal(new_state["fields"]["t_100"], original["t_100"])
+    # unrelated fields and humidity fields are unchanged
+    np.testing.assert_array_equal(new_state["fields"]["msl"], original["msl"])
+    np.testing.assert_array_equal(new_state["fields"]["q_850"], original["q_850"])
+
+
+def test_compute_tv_does_not_mutate_input(mock_state: State):
+    original = {k: v.copy() for k, v in mock_state["fields"].items()}
+    processor = _make_processor()
+
+    processor.process(mock_state)
+
+    # the original state's fields dict must be untouched
+    for key, value in original.items():
+        np.testing.assert_array_equal(mock_state["fields"][key], value)


### PR DESCRIPTION
### Description

This adds the `compute_tv` plugin for anemoi-inference to compute virtual temperature. Used in the nudging suites.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
