### PR TITLE
feat: Virtual temperature filter

### DIFF
--- a/transform/README.md
+++ b/transform/README.md
@@ -6,6 +6,7 @@ This package includes all plugins developed for anemoi transform developed by EC
 
 | Plugin    | Description                        |
 |-----------|------------------------------------|
+| VirtualTemperature | Compute VirtualTemperature from q and t |
 
 
 See the underlying code for a more detailed `README`.

--- a/transform/pyproject.toml
+++ b/transform/pyproject.toml
@@ -52,7 +52,7 @@ optional-dependencies.tests = [
 urls.Homepage = "https://github.com/ecmwf/anemoi-plugins-ecmwf"
 
 ## Entry Points
-entry-points."anemoi.transform.filters.fields".compute_tv = "anemoi.plugins.ecmwf.transform.compute_tv.compute_tv:ComputeTV"
+entry-points."anemoi.transform.filters.fields".virtual_temperature = "anemoi.plugins.ecmwf.transform.virtual_temperature:VirtualTemperature"
 
 [dependency-groups]
 dev = [

--- a/transform/src/anemoi/plugins/ecmwf/transform/virtual_temperature/README.md
+++ b/transform/src/anemoi/plugins/ecmwf/transform/virtual_temperature/README.md
@@ -1,0 +1,7 @@
+# Virtual Temperature
+
+A post processor that take `q` and `t` to compute `vtmp` for nudging workflows.
+
+```math
+vtmp=(1+0.61*q)*T
+```

--- a/transform/src/anemoi/plugins/ecmwf/transform/virtual_temperature/__init__.py
+++ b/transform/src/anemoi/plugins/ecmwf/transform/virtual_temperature/__init__.py
@@ -1,0 +1,13 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+from .virtual_temperature import VirtualTemperature
+
+__all__ = ["VirtualTemperature"]

--- a/transform/src/anemoi/plugins/ecmwf/transform/virtual_temperature/virtual_temperature.py
+++ b/transform/src/anemoi/plugins/ecmwf/transform/virtual_temperature/virtual_temperature.py
@@ -1,0 +1,57 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from collections.abc import Iterator
+
+import earthkit.data as ekd
+from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
+from anemoi.transform.filters.fields.matching import MatchingSpec
+
+
+class VirtualTemperature(MatchingFieldsFilter):
+
+    MATCHING = MatchingSpec(
+        select="param",
+        forward=("specific_humidity", "temperature"),
+        skip_partial=True,
+        return_inputs="all",
+    )
+
+    def __init__(
+        self,
+        *,
+        virtual_temperature: str = "vtmp",
+        specific_humidity: str = "q",
+        temperature: str = "t",
+    ):
+        """Initialise the VirtualTemperature filter.
+
+        Compute the virtual temperature from specific humidity and temperature,
+        using
+        ```
+        vtmp = (1 + 0.61 * q) * t
+        ```
+
+        Parameters
+        ----------
+        virtual_temperature: str, optional
+            Name of the virtual temperature parameter, by default "vtmp".
+        specific_humidity : str, optional
+            Name of the specific humidity parameter, by default "q".
+        temperature : str, optional
+            Name of the temperature parameter, by default "t".
+        """
+        self.specific_humidity = specific_humidity
+        self.temperature = temperature
+        self.virtual_temperature = virtual_temperature
+        super().__init__()
+
+    def forward_transform(self, specific_humidity: ekd.Field, temperature: ekd.Field) -> Iterator[ekd.Field]:
+        vtmp = (1 + 0.61 * specific_humidity.to_numpy()) * temperature.to_numpy()
+        yield self.new_field_from_numpy(vtmp, template=specific_humidity, param=self.virtual_temperature)

--- a/transform/src/anemoi/plugins/ecmwf/transform/virtual_temperature/virtual_temperature.py
+++ b/transform/src/anemoi/plugins/ecmwf/transform/virtual_temperature/virtual_temperature.py
@@ -19,7 +19,6 @@ class VirtualTemperature(MatchingFieldsFilter):
     MATCHING = MatchingSpec(
         select="param",
         forward=("specific_humidity", "temperature"),
-        skip_partial=True,
         return_inputs="all",
     )
 

--- a/transform/tests/virtual_temperature/test_virtual_temperature.py
+++ b/transform/tests/virtual_temperature/test_virtual_temperature.py
@@ -1,0 +1,111 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+import earthkit.data as ekd
+import numpy as np
+import pytest
+from anemoi.plugins.ecmwf.transform.virtual_temperature import VirtualTemperature
+
+NPOINTS = 20
+
+
+def make_field(param: str, values: np.ndarray, **metadata) -> ekd.ArrayField:
+    return ekd.ArrayField(values, {"param": param, **metadata})
+
+
+@pytest.fixture
+def mock_fields() -> ekd.FieldList:
+    """A field list containing specific humidity, temperature and an unrelated field."""
+    return ekd.FieldList.from_fields(
+        [
+            make_field("q", np.random.uniform(0.0, 0.02, size=NPOINTS)),
+            make_field("t", np.random.uniform(220.0, 310.0, size=NPOINTS)),
+            make_field("msl", np.random.uniform(500.0, 1500.0, size=NPOINTS)),
+        ]
+    )
+
+
+def test_virtual_temperature_computes_vtmp(mock_fields: ekd.FieldList):
+    q = mock_fields.sel(param="q")[0].to_numpy()
+    t = mock_fields.sel(param="t")[0].to_numpy()
+
+    result = VirtualTemperature().forward(mock_fields)
+
+    vtmp = result.sel(param="vtmp")[0].to_numpy()
+    np.testing.assert_allclose(vtmp, (1.0 + 0.61 * q) * t)
+
+
+def test_virtual_temperature_returns_inputs(mock_fields: ekd.FieldList):
+    result = VirtualTemperature().forward(mock_fields)
+
+    # the new field is added alongside the (unchanged) inputs
+    params = sorted(result.metadata("param"))
+    assert params == ["msl", "q", "t", "vtmp"]
+
+    np.testing.assert_array_equal(
+        result.sel(param="q")[0].to_numpy(), mock_fields.sel(param="q")[0].to_numpy()
+    )
+    np.testing.assert_array_equal(
+        result.sel(param="t")[0].to_numpy(), mock_fields.sel(param="t")[0].to_numpy()
+    )
+    np.testing.assert_array_equal(
+        result.sel(param="msl")[0].to_numpy(), mock_fields.sel(param="msl")[0].to_numpy()
+    )
+
+
+def test_virtual_temperature_custom_names():
+    q = np.random.uniform(0.0, 0.02, size=NPOINTS)
+    t = np.random.uniform(220.0, 310.0, size=NPOINTS)
+    fields = ekd.FieldList.from_fields(
+        [make_field("spec_hum", q), make_field("temp", t)]
+    )
+
+    result = VirtualTemperature(
+        virtual_temperature="virt_t",
+        specific_humidity="spec_hum",
+        temperature="temp",
+    ).forward(fields)
+
+    vtmp = result.sel(param="virt_t")[0].to_numpy()
+    np.testing.assert_allclose(vtmp, (1.0 + 0.61 * q) * t)
+
+
+def test_virtual_temperature_multiple_levels():
+    """A vtmp field is produced for every level where both q and t are present."""
+    data = {}
+    fields = []
+    for level in (850, 500):
+        q = np.random.uniform(0.0, 0.02, size=NPOINTS)
+        t = np.random.uniform(220.0, 310.0, size=NPOINTS)
+        data[level] = (q, t)
+        fields.append(make_field("q", q, levelist=level))
+        fields.append(make_field("t", t, levelist=level))
+
+    result = VirtualTemperature().forward(ekd.FieldList.from_fields(fields))
+
+    vtmp_fields = result.sel(param="vtmp")
+    assert len(vtmp_fields) == 2
+    for field in vtmp_fields:
+        level = field.metadata("levelist")
+        q, t = data[level]
+        np.testing.assert_allclose(field.to_numpy(), (1.0 + 0.61 * q) * t)
+
+
+def test_virtual_temperature_unpaired_temperature_raises():
+    """A temperature field without a matching humidity field is an error."""
+    fields = ekd.FieldList.from_fields(
+        [
+            make_field("q", np.random.uniform(0.0, 0.02, size=NPOINTS), levelist=850),
+            make_field("t", np.random.uniform(220.0, 310.0, size=NPOINTS), levelist=850),
+            # temperature at 500 hPa has no matching humidity
+            make_field("t", np.random.uniform(220.0, 310.0, size=NPOINTS), levelist=500),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Missing component"):
+        VirtualTemperature().forward(fields)

--- a/transform/tests/virtual_temperature/test_virtual_temperature.py
+++ b/transform/tests/virtual_temperature/test_virtual_temperature.py
@@ -47,23 +47,15 @@ def test_virtual_temperature_returns_inputs(mock_fields: ekd.FieldList):
     params = sorted(result.metadata("param"))
     assert params == ["msl", "q", "t", "vtmp"]
 
-    np.testing.assert_array_equal(
-        result.sel(param="q")[0].to_numpy(), mock_fields.sel(param="q")[0].to_numpy()
-    )
-    np.testing.assert_array_equal(
-        result.sel(param="t")[0].to_numpy(), mock_fields.sel(param="t")[0].to_numpy()
-    )
-    np.testing.assert_array_equal(
-        result.sel(param="msl")[0].to_numpy(), mock_fields.sel(param="msl")[0].to_numpy()
-    )
+    np.testing.assert_array_equal(result.sel(param="q")[0].to_numpy(), mock_fields.sel(param="q")[0].to_numpy())
+    np.testing.assert_array_equal(result.sel(param="t")[0].to_numpy(), mock_fields.sel(param="t")[0].to_numpy())
+    np.testing.assert_array_equal(result.sel(param="msl")[0].to_numpy(), mock_fields.sel(param="msl")[0].to_numpy())
 
 
 def test_virtual_temperature_custom_names():
     q = np.random.uniform(0.0, 0.02, size=NPOINTS)
     t = np.random.uniform(220.0, 310.0, size=NPOINTS)
-    fields = ekd.FieldList.from_fields(
-        [make_field("spec_hum", q), make_field("temp", t)]
-    )
+    fields = ekd.FieldList.from_fields([make_field("spec_hum", q), make_field("temp", t)])
 
     result = VirtualTemperature(
         virtual_temperature="virt_t",


### PR DESCRIPTION
### Description
Alternate to #97. Add virtual temperature as a filter for anemoi-transforms, relying upon the existing matching infrastructure.
Allows for grib writing, under the correct keys.

> [!NOTE]
> ## TODO
> - [x] Add tests
> - [ ] Improve documentation

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
